### PR TITLE
[ADD] create comment and board, comment 

### DIFF
--- a/src/main/java/com/server/Dotori/config/querydsl/QuerydslConfiguration.java
+++ b/src/main/java/com/server/Dotori/config/querydsl/QuerydslConfiguration.java
@@ -1,0 +1,19 @@
+package com.server.Dotori.config.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfiguration {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/server/Dotori/model/board/Board.java
+++ b/src/main/java/com/server/Dotori/model/board/Board.java
@@ -37,10 +37,6 @@ public class Board extends BaseTimeEntity {
     @Column(name = "board_content", length = 500, nullable = false)
     private String content;
 
-    @OneToMany(mappedBy = "board")
-    @JsonManagedReference
-    private List<Comment> comments = new ArrayList<>();
-
     public void updateBoard(String title, String content) {
         this.title = title != null ? title : this.title;
         this.content = content != null ? content : this.content;

--- a/src/main/java/com/server/Dotori/model/board/controller/admin/AdminBoardController.java
+++ b/src/main/java/com/server/Dotori/model/board/controller/admin/AdminBoardController.java
@@ -1,8 +1,10 @@
 package com.server.Dotori.model.board.controller.admin;
 
+import com.querydsl.core.Tuple;
+import com.server.Dotori.model.board.Board;
 import com.server.Dotori.model.board.dto.BoardGetDto;
-import com.server.Dotori.model.board.dto.BoardGetIdDto;
 import com.server.Dotori.model.board.dto.BoardDto;
+import com.server.Dotori.model.board.dto.BoardGetIdDto;
 import com.server.Dotori.model.board.service.BoardService;
 import com.server.Dotori.response.ResponseService;
 import com.server.Dotori.response.result.CommonResult;
@@ -12,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/v1/admin")

--- a/src/main/java/com/server/Dotori/model/board/dto/BoardGetIdDto.java
+++ b/src/main/java/com/server/Dotori/model/board/dto/BoardGetIdDto.java
@@ -4,6 +4,7 @@ import com.server.Dotori.model.comment.Comment;
 import com.server.Dotori.model.member.enumType.Role;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,9 +17,11 @@ public class BoardGetIdDto {
     private Long id;
     private String title;
     private String content;
-    private List<Comment> comments;
     private List<Role> roles;
 
     @CreatedDate
     private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
 }

--- a/src/main/java/com/server/Dotori/model/board/repository/BoardRepository.java
+++ b/src/main/java/com/server/Dotori/model/board/repository/BoardRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface BoardRepository extends JpaRepository<Board, Long> {
+public interface BoardRepository extends JpaRepository<Board, Long>, BoardRepositoryCustom {
 
 }

--- a/src/main/java/com/server/Dotori/model/board/repository/BoardRepositoryCustom.java
+++ b/src/main/java/com/server/Dotori/model/board/repository/BoardRepositoryCustom.java
@@ -1,0 +1,7 @@
+package com.server.Dotori.model.board.repository;
+
+import com.querydsl.core.Tuple;
+
+public interface BoardRepositoryCustom {
+
+}

--- a/src/main/java/com/server/Dotori/model/board/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/model/board/repository/BoardRepositoryImpl.java
@@ -1,0 +1,15 @@
+package com.server.Dotori.model.board.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import static com.server.Dotori.model.board.QBoard.board;
+import static com.server.Dotori.model.comment.QComment.comment;
+
+@RequiredArgsConstructor
+public class BoardRepositoryImpl implements BoardRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+}

--- a/src/main/java/com/server/Dotori/model/board/service/BoardService.java
+++ b/src/main/java/com/server/Dotori/model/board/service/BoardService.java
@@ -1,9 +1,10 @@
 package com.server.Dotori.model.board.service;
 
+import com.querydsl.core.Tuple;
 import com.server.Dotori.model.board.Board;
 import com.server.Dotori.model.board.dto.BoardGetDto;
-import com.server.Dotori.model.board.dto.BoardGetIdDto;
 import com.server.Dotori.model.board.dto.BoardDto;
+import com.server.Dotori.model.board.dto.BoardGetIdDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 

--- a/src/main/java/com/server/Dotori/model/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/board/service/BoardServiceImpl.java
@@ -1,13 +1,11 @@
 package com.server.Dotori.model.board.service;
 
+import com.querydsl.core.Tuple;
 import com.server.Dotori.exception.board.exception.BoardNotFoundException;
-import com.server.Dotori.exception.board.exception.BoardNotHavePermissionToCreate;
-import com.server.Dotori.exception.board.exception.BoardNotHavePermissionToDelete;
-import com.server.Dotori.exception.board.exception.BoardNotHavePermissionToModify;
 import com.server.Dotori.model.board.Board;
 import com.server.Dotori.model.board.dto.BoardGetDto;
-import com.server.Dotori.model.board.dto.BoardGetIdDto;
 import com.server.Dotori.model.board.dto.BoardDto;
+import com.server.Dotori.model.board.dto.BoardGetIdDto;
 import com.server.Dotori.model.board.repository.BoardRepository;
 import com.server.Dotori.model.member.Member;
 import com.server.Dotori.util.CurrentUserUtil;
@@ -17,10 +15,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Collections;
-
-import static com.server.Dotori.model.member.enumType.Role.*;
 
 @Service
 @RequiredArgsConstructor
@@ -51,6 +45,7 @@ public class BoardServiceImpl implements BoardService {
 
     @Override
     public BoardGetIdDto getBoardById(Long boardId) {
+
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(() -> new BoardNotFoundException());
 

--- a/src/main/java/com/server/Dotori/model/comment/Comment.java
+++ b/src/main/java/com/server/Dotori/model/comment/Comment.java
@@ -23,6 +23,7 @@ public class Comment extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne
+    @JsonBackReference
     @JoinColumn(name = "board_id", nullable = false)
     private Board board;
 

--- a/src/main/java/com/server/Dotori/model/comment/controller/admin/AdminCommentController.java
+++ b/src/main/java/com/server/Dotori/model/comment/controller/admin/AdminCommentController.java
@@ -1,5 +1,9 @@
 package com.server.Dotori.model.comment.controller.admin;
 
+import com.server.Dotori.model.comment.dto.CommentDto;
+import com.server.Dotori.model.comment.service.CommentService;
+import com.server.Dotori.response.ResponseService;
+import com.server.Dotori.response.result.CommonResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -8,4 +12,12 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/v1/admin")
 public class AdminCommentController {
 
+    private final CommentService commentService;
+    private final ResponseService responseService;
+
+    @PostMapping("/board/{id}/comment")
+    public CommonResult createComment(@PathVariable("id") Long boardId, @RequestBody CommentDto commentDto) {
+        commentService.createComment(boardId, commentDto);
+        return responseService.getSuccessResult();
+    }
 }

--- a/src/main/java/com/server/Dotori/model/comment/dto/CommentDto.java
+++ b/src/main/java/com/server/Dotori/model/comment/dto/CommentDto.java
@@ -1,0 +1,22 @@
+package com.server.Dotori.model.comment.dto;
+
+import com.server.Dotori.model.board.Board;
+import com.server.Dotori.model.comment.Comment;
+import com.server.Dotori.model.member.Member;
+import lombok.*;
+
+@Getter @Setter @Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentDto {
+
+    private String contents;
+
+    public Comment saveToEntity(Board board, Member member) {
+        return Comment.builder()
+                .board(board)
+                .member(member)
+                .contents(contents)
+                .build();
+    }
+}

--- a/src/main/java/com/server/Dotori/model/comment/service/CommentService.java
+++ b/src/main/java/com/server/Dotori/model/comment/service/CommentService.java
@@ -1,0 +1,8 @@
+package com.server.Dotori.model.comment.service;
+
+import com.server.Dotori.model.comment.dto.CommentDto;
+
+public interface CommentService {
+
+    Long createComment(Long boardId, CommentDto commentDto);
+}

--- a/src/main/java/com/server/Dotori/model/comment/service/CommentService.java
+++ b/src/main/java/com/server/Dotori/model/comment/service/CommentService.java
@@ -1,8 +1,9 @@
 package com.server.Dotori.model.comment.service;
 
+import com.server.Dotori.model.comment.Comment;
 import com.server.Dotori.model.comment.dto.CommentDto;
 
 public interface CommentService {
 
-    Long createComment(Long boardId, CommentDto commentDto);
+    Comment createComment(Long boardId, CommentDto commentDto);
 }

--- a/src/main/java/com/server/Dotori/model/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/comment/service/CommentServiceImpl.java
@@ -1,0 +1,35 @@
+package com.server.Dotori.model.comment.service;
+
+import com.server.Dotori.exception.board.exception.BoardNotFoundException;
+import com.server.Dotori.model.board.Board;
+import com.server.Dotori.model.board.repository.BoardRepository;
+import com.server.Dotori.model.comment.Comment;
+import com.server.Dotori.model.comment.dto.CommentDto;
+import com.server.Dotori.model.comment.repository.CommentRepository;
+import com.server.Dotori.model.member.Member;
+import com.server.Dotori.model.member.repository.MemberRepository;
+import com.server.Dotori.util.CurrentUserUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentServiceImpl implements CommentService {
+
+    private final BoardRepository boardRepository;
+    private final MemberRepository memberRepository;
+    private final CommentRepository commentRepository;
+    private final CurrentUserUtil currentUserUtil;
+
+    @Override
+    public Long createComment(Long boardId, CommentDto commentDto) {
+
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new BoardNotFoundException());
+
+        Member currentUser = currentUserUtil.getCurrentUser();
+
+        Comment comment = commentRepository.save(commentDto.saveToEntity(board, currentUser));
+        return comment.getId();
+    }
+}

--- a/src/main/java/com/server/Dotori/model/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/comment/service/CommentServiceImpl.java
@@ -22,14 +22,17 @@ public class CommentServiceImpl implements CommentService {
     private final CurrentUserUtil currentUserUtil;
 
     @Override
-    public Long createComment(Long boardId, CommentDto commentDto) {
+    public Comment createComment(Long boardId, CommentDto commentDto) {
 
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(() -> new BoardNotFoundException());
 
         Member currentUser = currentUserUtil.getCurrentUser();
 
-        Comment comment = commentRepository.save(commentDto.saveToEntity(board, currentUser));
-        return comment.getId();
+        Comment comment = commentRepository.save(
+                commentDto.saveToEntity(board, currentUser)
+        );
+
+        return comment;
     }
 }

--- a/src/test/java/com/server/Dotori/model/board/service/BoardServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/board/service/BoardServiceTest.java
@@ -1,14 +1,16 @@
 package com.server.Dotori.model.board.service;
 
+import com.querydsl.core.Tuple;
 import com.server.Dotori.model.board.Board;
 import com.server.Dotori.model.board.dto.BoardGetDto;
-import com.server.Dotori.model.board.dto.BoardGetIdDto;
 import com.server.Dotori.model.board.dto.BoardDto;
+import com.server.Dotori.model.board.dto.BoardGetIdDto;
 import com.server.Dotori.model.board.repository.BoardRepository;
 import com.server.Dotori.model.member.dto.MemberDto;
 import com.server.Dotori.model.member.enumType.Role;
 import com.server.Dotori.model.member.repository.MemberRepository;
 import com.server.Dotori.util.CurrentUserUtil;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,8 +34,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
-//@Transactional
-@Commit
+@Transactional
+//@Commit
 class BoardServiceTest {
 
     @Autowired

--- a/src/test/java/com/server/Dotori/model/board/service/BoardServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/board/service/BoardServiceTest.java
@@ -32,7 +32,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
-@Transactional
+//@Transactional
+@Commit
 class BoardServiceTest {
 
     @Autowired

--- a/src/test/java/com/server/Dotori/model/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/comment/service/CommentServiceTest.java
@@ -1,0 +1,93 @@
+package com.server.Dotori.model.comment.service;
+
+import com.server.Dotori.exception.board.exception.BoardNotFoundException;
+import com.server.Dotori.model.board.Board;
+import com.server.Dotori.model.board.dto.BoardDto;
+import com.server.Dotori.model.board.repository.BoardRepository;
+import com.server.Dotori.model.board.service.BoardService;
+import com.server.Dotori.model.comment.dto.CommentDto;
+import com.server.Dotori.model.member.dto.MemberDto;
+import com.server.Dotori.model.member.enumType.Role;
+import com.server.Dotori.model.member.repository.MemberRepository;
+import com.server.Dotori.util.CurrentUserUtil;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.annotation.Commit;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Commit
+class CommentServiceTest {
+
+    @Autowired private CommentService commentService;
+    @Autowired private BoardService boardService;
+    @Autowired private BoardRepository boardRepository;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void before() {
+        MemberDto memberDto = MemberDto.builder()
+                .username("배태현")
+                .stdNum("2409")
+                .password("0809")
+                .email("s20032@gsm.hs.kr")
+                .build();
+        memberDto.setPassword(passwordEncoder.encode(memberDto.getPassword()));
+        memberRepository.save(memberDto.toEntity(Role.ROLE_ADMIN));
+        System.out.println("======== saved =========");
+
+        // when login session 발급
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
+                memberDto.getUsername(),
+                memberDto.getPassword(),
+                List.of(new SimpleGrantedAuthority(Role.ROLE_ADMIN.name())));
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(token);
+        System.out.println("=================================");
+        System.out.println(context);
+
+        //then
+        String currentUsername = CurrentUserUtil.getCurrentUserNickname();
+        assertEquals("배태현", currentUsername);
+
+        boardService.createBoard(
+                BoardDto.builder()
+                        .title("도토리 공지사항")
+                        .content("도토리 공지사항 생성 테스트")
+                        .build()
+        );
+    }
+
+    @Test
+    public void createCommentTest() {
+        //given
+        Board board = boardRepository.findById(1L)
+                .orElseThrow(() -> new BoardNotFoundException());
+        //when
+
+        //then
+
+        Long comment = commentService.createComment(
+                board.getId(),
+                CommentDto.builder()
+                        .contents("댓글")
+                        .build()
+        );
+
+        Assertions.assertThat(comment).isEqualTo(board.getId());
+
+    }
+}

--- a/src/test/java/com/server/Dotori/model/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/comment/service/CommentServiceTest.java
@@ -5,6 +5,7 @@ import com.server.Dotori.model.board.Board;
 import com.server.Dotori.model.board.dto.BoardDto;
 import com.server.Dotori.model.board.repository.BoardRepository;
 import com.server.Dotori.model.board.service.BoardService;
+import com.server.Dotori.model.comment.Comment;
 import com.server.Dotori.model.comment.dto.CommentDto;
 import com.server.Dotori.model.member.dto.MemberDto;
 import com.server.Dotori.model.member.enumType.Role;
@@ -12,6 +13,7 @@ import com.server.Dotori.model.member.repository.MemberRepository;
 import com.server.Dotori.util.CurrentUserUtil;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -62,32 +64,28 @@ class CommentServiceTest {
         //then
         String currentUsername = CurrentUserUtil.getCurrentUserNickname();
         assertEquals("배태현", currentUsername);
+    }
 
-        boardService.createBoard(
+    @Test
+    @DisplayName("게시글에 댓글이 잘 생성되는지 확인하는 테스트")
+    public void createCommentTest() {
+        //given
+        Board board = boardService.createBoard(
                 BoardDto.builder()
                         .title("도토리 공지사항")
                         .content("도토리 공지사항 생성 테스트")
                         .build()
         );
-    }
 
-    @Test
-    public void createCommentTest() {
-        //given
-        Board board = boardRepository.findById(1L)
-                .orElseThrow(() -> new BoardNotFoundException());
         //when
-
-        //then
-
-        Long comment = commentService.createComment(
+        Comment comment = commentService.createComment(
                 board.getId(),
                 CommentDto.builder()
                         .contents("댓글")
                         .build()
         );
 
-        Assertions.assertThat(comment).isEqualTo(board.getId());
-
+        //then
+        assertEquals(comment.getContents(), "댓글");
     }
 }


### PR DESCRIPTION
### 한 일
* comment 작성 기능

### 공지사항, 댓글 설계를 변경하려고 합니다
* 원래 하려고 했던 방법은
해당 아이디의 공지사항을 조회하면 공지사항의 상세정보와 그 공지사항의 댓글을 모두 조회해오는 방식입니다

* 바꾸려고 하는 방법은
해당 아이디의 공지사항을 조회하면 먼저 공지사항을 상세조회합니다.
> 댓글을 분리하여 따로 조회합니다.

`ex) 댓글 보러가기 클릭 시 -> 해당 공지사항의 댓글보여주는 방식`
공지사항 옆에 사이드바 처럼 댓글을 띄우거나, 
페이지를 나누어 해당 공지사항의 댓글을 띄우는 방법

### 클라이언트와 상의 결과
-> 공지사항은 보통 통보식으로 진행되오니 댓글기능을 없애는 방향을 생각해보자고 하였습니다.

### clean build result
<img width="282" alt="스크린샷 2021-07-30 오후 2 16 47" src="https://user-images.githubusercontent.com/69895394/127604672-a282aece-bfb7-4834-b0ec-d8eecfa70042.png">
