### PR TITLE
[ADD] music Application

### DIFF
--- a/src/main/java/com/server/Dotori/model/board/controller/admin/AdminBoardController.java
+++ b/src/main/java/com/server/Dotori/model/board/controller/admin/AdminBoardController.java
@@ -8,6 +8,8 @@ import com.server.Dotori.model.board.dto.BoardGetIdDto;
 import com.server.Dotori.model.board.service.BoardService;
 import com.server.Dotori.response.ResponseService;
 import com.server.Dotori.response.result.CommonResult;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,30 +29,54 @@ public class AdminBoardController {
 
     @PostMapping("/board")
     @ResponseStatus( HttpStatus.CREATED )
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
     public CommonResult createBoard(@RequestBody BoardDto boardDto) {
         boardService.createBoard(boardDto);
         return responseService.getSuccessResult();
     }
 
     @GetMapping("/board")
+    @ResponseStatus( HttpStatus.OK )
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
     public CommonResult getAllBoard(@PageableDefault(size = 5) Pageable pageable) {
         Page<BoardGetDto> pageBoard = boardService.getAllBoard(pageable);
         return responseService.getSingleResult(pageBoard);
     }
 
     @GetMapping("/board/{id}")
+    @ResponseStatus( HttpStatus.OK )
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
     public CommonResult getBoardById(@PathVariable("id") Long boardId) {
         BoardGetIdDto findBoardById = boardService.getBoardById(boardId);
         return responseService.getSingleResult(findBoardById);
     }
 
     @PutMapping("/board/{id}")
+    @ResponseStatus( HttpStatus.OK )
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
     public CommonResult updateBoard(@PathVariable("id") Long boardId, @RequestBody BoardDto boardUpdateDto) {
         boardService.updateBoard(boardId, boardUpdateDto);
         return responseService.getSuccessResult();
     }
 
     @DeleteMapping("/board/{id}")
+    @ResponseStatus( HttpStatus.NO_CONTENT )
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
     public CommonResult deleteBoard(@PathVariable("id") Long boardId) {
         boardService.deleteBoard(boardId);
         return responseService.getSuccessResult();

--- a/src/main/java/com/server/Dotori/model/member/Member.java
+++ b/src/main/java/com/server/Dotori/model/member/Member.java
@@ -101,11 +101,7 @@ public class Member implements UserDetails {
         return true;
     }
 
-    private void updatePassword(Member member) {
-        this.password = password != null ? password : this.password;
-    }
-
-    private void updatePoint(Member member) {
-        this.point = point != null ? point : this.point;
+    public void updateMusic(Music music) {
+        this.music = music != null ? music : this.music;
     }
 }

--- a/src/main/java/com/server/Dotori/model/music/dto/MusicApplicationDto.java
+++ b/src/main/java/com/server/Dotori/model/music/dto/MusicApplicationDto.java
@@ -1,0 +1,26 @@
+package com.server.Dotori.model.music.dto;
+
+import com.server.Dotori.model.board.Board;
+import com.server.Dotori.model.member.Member;
+import com.server.Dotori.model.music.Music;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter @Builder
+@NoArgsConstructor @AllArgsConstructor
+public class MusicApplicationDto {
+
+    @NotNull
+    private String musicUrl;
+
+    public Music saveToEntity(Member member) {
+        return Music.builder()
+                .member(member)
+                .url(musicUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/server/Dotori/model/music/service/MusicService.java
+++ b/src/main/java/com/server/Dotori/model/music/service/MusicService.java
@@ -1,0 +1,9 @@
+package com.server.Dotori.model.music.service;
+
+import com.server.Dotori.model.music.Music;
+import com.server.Dotori.model.music.dto.MusicApplicationDto;
+
+public interface MusicService {
+
+    Music musicApplication(MusicApplicationDto musicApplicationDto);
+}

--- a/src/main/java/com/server/Dotori/model/music/service/MusicServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/music/service/MusicServiceImpl.java
@@ -1,0 +1,36 @@
+package com.server.Dotori.model.music.service;
+
+import com.server.Dotori.model.board.Board;
+import com.server.Dotori.model.member.Member;
+import com.server.Dotori.model.member.repository.MemberRepository;
+import com.server.Dotori.model.music.Music;
+import com.server.Dotori.model.music.dto.MusicApplicationDto;
+import com.server.Dotori.model.music.repository.MusicRepository;
+import com.server.Dotori.util.CurrentUserUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+
+import static com.server.Dotori.model.member.enumType.Music.*;
+
+@Service
+@RequiredArgsConstructor
+public class MusicServiceImpl implements MusicService {
+
+    private final MusicRepository musicRepository;
+    private final CurrentUserUtil currentUserUtil;
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional
+    public Music musicApplication(MusicApplicationDto musicApplicationDto) {
+        Member currentUser = currentUserUtil.getCurrentUser();
+
+        Music music = musicRepository.save(musicApplicationDto.saveToEntity(currentUser));
+        currentUser.updateMusic(APPLIED);
+
+        return music;
+    }
+}

--- a/src/main/java/com/server/Dotori/model/music/service/MusicServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/music/service/MusicServiceImpl.java
@@ -28,9 +28,13 @@ public class MusicServiceImpl implements MusicService {
     public Music musicApplication(MusicApplicationDto musicApplicationDto) {
         Member currentUser = currentUserUtil.getCurrentUser();
 
-        Music music = musicRepository.save(musicApplicationDto.saveToEntity(currentUser));
-        currentUser.updateMusic(APPLIED);
+        if (currentUser.getMusic() == CAN) {
+            Music music = musicRepository.save(musicApplicationDto.saveToEntity(currentUser));
+            currentUser.updateMusic(APPLIED);
+            return music;
 
-        return music;
+        } else {
+            throw new IllegalArgumentException("이미 음악을 신청하신 회원입니다"); //Exception생성하여 예외처리하기
+        }
     }
 }

--- a/src/test/java/com/server/Dotori/model/music/service/MusicServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/music/service/MusicServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.annotation.Commit;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -28,7 +29,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
-@Commit
+@Transactional
+//@Commit
 class MusicServiceTest {
 
     @Autowired private MusicService musicService;

--- a/src/test/java/com/server/Dotori/model/music/service/MusicServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/music/service/MusicServiceTest.java
@@ -1,0 +1,83 @@
+package com.server.Dotori.model.music.service;
+
+import com.server.Dotori.model.member.Member;
+import com.server.Dotori.model.member.dto.MemberDto;
+import com.server.Dotori.model.member.enumType.Role;
+import com.server.Dotori.model.member.repository.MemberRepository;
+import com.server.Dotori.model.music.Music;
+import com.server.Dotori.model.music.dto.MusicApplicationDto;
+import com.server.Dotori.model.music.repository.MusicRepository;
+import com.server.Dotori.util.CurrentUserUtil;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.annotation.Commit;
+
+import java.util.List;
+
+import static com.server.Dotori.model.member.enumType.Music.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Commit
+class MusicServiceTest {
+
+    @Autowired private MusicService musicService;
+    @Autowired private MusicRepository musicRepository;
+    @Autowired private PasswordEncoder passwordEncoder;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private CurrentUserUtil currentUserUtil;
+
+    @BeforeEach
+    @DisplayName("로그인 되어있는 유저를 확인하는 테스트")
+    void currentUser() {
+        //given
+        MemberDto memberDto = MemberDto.builder()
+                .username("배태현")
+                .stdNum("2409")
+                .password("0809")
+                .email("s20032@gsm.hs.kr")
+                .build();
+        memberDto.setPassword(passwordEncoder.encode(memberDto.getPassword()));
+        memberRepository.save(memberDto.toEntity(Role.ROLE_ADMIN));
+        System.out.println("======== saved =========");
+
+        // when login session 발급
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
+                memberDto.getUsername(),
+                memberDto.getPassword(),
+                List.of(new SimpleGrantedAuthority(Role.ROLE_ADMIN.name())));
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(token);
+        System.out.println("=================================");
+        System.out.println(context);
+
+        //then
+        String currentUsername = CurrentUserUtil.getCurrentUserNickname();
+        assertEquals("배태현", currentUsername);
+    }
+
+    @Test
+    @DisplayName("음악신청이 제대로 되는지 확인하는 테스트")
+    public void musicApplicationTest() {
+        //given //when
+        Music music = musicService.musicApplication(
+                MusicApplicationDto.builder()
+                        .musicUrl("https://www.youtube.com/watch?v=6h9qmKWK6Io")
+                        .build()
+        );
+
+        //then
+        assertThat(music.getMember().getMusic()).isEqualTo(APPLIED);
+        assertThat(music.getUrl()).isEqualTo("https://www.youtube.com/watch?v=6h9qmKWK6Io");
+    }
+}


### PR DESCRIPTION
음악 신청 기능 개발 완료했습니다.

음악신청 시 **member**의 **music**이 `APPLIED`로 변경하는 것을 **DB, Test코드로 검증완료** 했습니다.

++ 추가로 Board컨트롤러에 토큰 입력란 추가했습니다. (Swagger)

<img width="1305" alt="스크린샷 2021-08-01 오후 4 52 32" src="https://user-images.githubusercontent.com/69895394/127763724-4f7f4cc2-0417-4743-ac68-9b506f0d1f4a.png">

### clean build result
<img width="295" alt="스크린샷 2021-08-01 오후 4 42 11" src="https://user-images.githubusercontent.com/69895394/127763596-1d45f1a7-b030-419e-8337-05ebba28cb12.png">


### **Member**의 `dirty checking`(update) 로직이 이상하여 다 지웠습니다
@TeMlN 다시 작성하시기 바랍니다