### PR TITLE
[ADD] 자습신청

### DIFF
--- a/src/main/java/com/server/Dotori/model/member/Member.java
+++ b/src/main/java/com/server/Dotori/model/member/Member.java
@@ -104,4 +104,8 @@ public class Member implements UserDetails {
     public void updateMusic(Music music) {
         this.music = music != null ? music : this.music;
     }
+
+    public void updateSelfStudy(SelfStudy selfStudy) {
+        this.selfStudy = selfStudy != null ? selfStudy : this.selfStudy;
+    }
 }

--- a/src/main/java/com/server/Dotori/model/selfstudy/controller/SelfStudyController.java
+++ b/src/main/java/com/server/Dotori/model/selfstudy/controller/SelfStudyController.java
@@ -1,0 +1,2 @@
+package com.server.Dotori.model.selfstudy.controller;public class SelfStudyController {
+}

--- a/src/main/java/com/server/Dotori/model/selfstudy/controller/SelfStudyController.java
+++ b/src/main/java/com/server/Dotori/model/selfstudy/controller/SelfStudyController.java
@@ -18,7 +18,7 @@ public class SelfStudyController {
     private final ResponseService responseService;
     private final SelfStudyService selfStudyService;
 
-    @GetMapping ("/selfstudy")
+    @PutMapping("/selfstudy")
     @ResponseStatus( HttpStatus.CREATED )
     @ApiImplicitParams({
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),

--- a/src/main/java/com/server/Dotori/model/selfstudy/controller/SelfStudyController.java
+++ b/src/main/java/com/server/Dotori/model/selfstudy/controller/SelfStudyController.java
@@ -1,2 +1,31 @@
-package com.server.Dotori.model.selfstudy.controller;public class SelfStudyController {
+package com.server.Dotori.model.selfstudy.controller;
+
+import com.server.Dotori.model.board.dto.BoardDto;
+import com.server.Dotori.model.selfstudy.service.SelfStudyService;
+import com.server.Dotori.response.ResponseService;
+import com.server.Dotori.response.result.CommonResult;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/v1/member")
+@RequiredArgsConstructor
+public class SelfStudyController {
+
+    private final ResponseService responseService;
+    private final SelfStudyService selfStudyService;
+
+    @GetMapping ("/selfstudy")
+    @ResponseStatus( HttpStatus.CREATED )
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
+    public CommonResult requestSelfStudy() {
+        selfStudyService.requestSelfStudy();
+        return responseService.getSuccessResult();
+    }
 }

--- a/src/main/java/com/server/Dotori/model/selfstudy/service/SelfStudyService.java
+++ b/src/main/java/com/server/Dotori/model/selfstudy/service/SelfStudyService.java
@@ -1,0 +1,2 @@
+package com.server.Dotori.model.selfstudy.service;public interface SelfStudyService {
+}

--- a/src/main/java/com/server/Dotori/model/selfstudy/service/SelfStudyService.java
+++ b/src/main/java/com/server/Dotori/model/selfstudy/service/SelfStudyService.java
@@ -1,2 +1,6 @@
-package com.server.Dotori.model.selfstudy.service;public interface SelfStudyService {
+package com.server.Dotori.model.selfstudy.service;
+
+public interface SelfStudyService {
+
+    void requestSelfStudy();
 }

--- a/src/main/java/com/server/Dotori/model/selfstudy/service/SelfStudyServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/selfstudy/service/SelfStudyServiceImpl.java
@@ -1,0 +1,4 @@
+package com.server.Dotori.model.selfstudy.service;
+
+public class SelfStudyServiceImpl {
+}

--- a/src/main/java/com/server/Dotori/model/selfstudy/service/SelfStudyServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/selfstudy/service/SelfStudyServiceImpl.java
@@ -1,4 +1,38 @@
 package com.server.Dotori.model.selfstudy.service;
 
-public class SelfStudyServiceImpl {
+import com.server.Dotori.model.member.Member;
+import com.server.Dotori.model.member.enumType.SelfStudy;
+import com.server.Dotori.model.member.repository.MemberRepository;
+import com.server.Dotori.util.CurrentUserUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.server.Dotori.model.member.enumType.SelfStudy.*;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SelfStudyServiceImpl implements SelfStudyService {
+
+    private final CurrentUserUtil currentUserUtil;
+
+    Integer count = 0;
+
+    @Override
+    @Transactional
+    public void requestSelfStudy() {
+        Member currentUser = currentUserUtil.getCurrentUser();
+
+        if (count <= 50){
+            if (currentUser.getSelfStudy() == CAN) {
+                currentUser.updateSelfStudy(APPLIED);
+                count += 1;
+                log.info(String.valueOf(count));
+            } else
+                throw new IllegalArgumentException("이미 자습을 신청한 학생입니다");
+        } else
+            throw new IllegalArgumentException("자습신청 인원이 모두 찼습니다.");
+    }
 }

--- a/src/test/java/com/server/Dotori/model/selfstudty/SelfStudyTest.java
+++ b/src/test/java/com/server/Dotori/model/selfstudty/SelfStudyTest.java
@@ -1,2 +1,0 @@
-package com.server.Dotori.model.selfstudty;public class SelfStudyTest {
-}

--- a/src/test/java/com/server/Dotori/model/selfstudy/service/SelfStudyServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/selfstudy/service/SelfStudyServiceTest.java
@@ -31,8 +31,7 @@ import static com.server.Dotori.model.member.enumType.SelfStudy.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
-@Commit
-//@Transactional
+@Transactional
 class SelfStudyServiceTest {
 
     @Autowired private PasswordEncoder passwordEncoder;

--- a/src/test/java/com/server/Dotori/model/selfstudy/service/SelfStudyServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/selfstudy/service/SelfStudyServiceTest.java
@@ -1,4 +1,79 @@
+package com.server.Dotori.model.selfstudy.service;
+
+import com.server.Dotori.model.member.Member;
+import com.server.Dotori.model.member.dto.MemberDto;
+import com.server.Dotori.model.member.dto.MemberLoginDto;
+import com.server.Dotori.model.member.enumType.Role;
+import com.server.Dotori.model.member.enumType.SelfStudy;
+import com.server.Dotori.model.member.repository.MemberRepository;
+import com.server.Dotori.model.member.service.MemberService;
+import com.server.Dotori.model.music.repository.MusicRepository;
+import com.server.Dotori.util.CurrentUserUtil;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.annotation.Commit;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.server.Dotori.model.member.enumType.Music.CAN;
+import static com.server.Dotori.model.member.enumType.SelfStudy.*;
 import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Commit
+//@Transactional
 class SelfStudyServiceTest {
-  
+
+    @Autowired private PasswordEncoder passwordEncoder;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private CurrentUserUtil currentUserUtil;
+    @Autowired private SelfStudyService selfStudyService;
+    @Autowired private MemberService memberService;
+
+    @BeforeEach
+    @DisplayName("로그인 되어있는 유저를 확인하는 테스트")
+    void currentUser() {
+        //given
+        MemberDto memberDto = MemberDto.builder()
+                .username("배태현")
+                .stdNum("2409")
+                .password("0809")
+                .email("s20032@gsm.hs.kr")
+                .build();
+        memberDto.setPassword(passwordEncoder.encode(memberDto.getPassword()));
+        memberRepository.save(memberDto.toEntity(Role.ROLE_ADMIN));
+        System.out.println("======== saved =========");
+
+        // when login session 발급
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
+                memberDto.getUsername(),
+                memberDto.getPassword(),
+                List.of(new SimpleGrantedAuthority(Role.ROLE_ADMIN.name())));
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(token);
+        System.out.println("=================================");
+        System.out.println(context);
+
+        //then
+        String currentUsername = CurrentUserUtil.getCurrentUserNickname();
+        assertEquals("배태현", currentUsername);
+    }
+
+    @Test
+    public void requestSelfStudyTest() {
+        selfStudyService.requestSelfStudy();
+
+        assertEquals(APPLIED, currentUserUtil.getCurrentUser().getSelfStudy());
+    }
 }

--- a/src/test/java/com/server/Dotori/model/selfstudy/service/SelfStudyServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/selfstudy/service/SelfStudyServiceTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class SelfStudyServiceTest {
+  
+}


### PR DESCRIPTION
### 제가 한 일이에요 !
* 자습신청 기능 개발 (50명 한도)
* 자습신청 서비스 테스트
* 50명 카운트 확인을 위해 컨트롤러를 미리 만들어 테스트해보았습니다.

---

### 카운트 확인 (log)
<img width="1148" alt="스크린샷 2021-08-25 오후 2 05 00" src="https://user-images.githubusercontent.com/69895394/130729900-8aef7453-96b1-4e75-9946-a9c3cd47510f.png">
<img width="1126" alt="스크린샷 2021-08-25 오후 2 06 29" src="https://user-images.githubusercontent.com/69895394/130729897-59001762-be8a-4125-8f33-47bc3cb60d1d.png">

---

### 데이터베이스에서 회원 자습신청 상태 확인
![스크린샷 2021-08-25 오후 1 38 37](https://user-images.githubusercontent.com/69895394/130729904-080cf85c-1d4e-4424-8d77-47e511198c7c.png)
> `CAN` -> `APPLIED`로 변경완료 확인