### PR TITLE
학생들의 자습신청 상태를 업데이트

### DIFF
--- a/src/main/java/com/server/Dotori/model/selfstudy/controller/SelfStudyController.java
+++ b/src/main/java/com/server/Dotori/model/selfstudy/controller/SelfStudyController.java
@@ -50,4 +50,15 @@ public class SelfStudyController {
     public SingleResult getSelfStudyStudents() {
         return responseService.getSingleResult(selfStudyService.getSelfStudyStudents());
     }
+
+    @PutMapping ("/selfstudy/status")
+    @ResponseStatus( HttpStatus.OK )
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
+    public CommonResult updateSelfStudyStatus() {
+        selfStudyService.updateSelfStudyStatus();
+        return responseService.getSuccessResult();
+    }
 }

--- a/src/main/java/com/server/Dotori/model/selfstudy/repository/SelfStudyRepositoryCustom.java
+++ b/src/main/java/com/server/Dotori/model/selfstudy/repository/SelfStudyRepositoryCustom.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface SelfStudyRepositoryCustom {
 
     List<SelfStudyStudentsDto> findBySelfStudyAPLLIED();
+
+    void updateSelfStudyStatus();
 }

--- a/src/main/java/com/server/Dotori/model/selfstudy/repository/SelfStudyRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/model/selfstudy/repository/SelfStudyRepositoryImpl.java
@@ -27,4 +27,17 @@ public class SelfStudyRepositoryImpl implements SelfStudyRepositoryCustom {
                         member.selfStudy.eq(SelfStudy.APPLIED)
                 ).fetch();
     }
+
+    @Override
+    public void updateSelfStudyStatus() {
+
+        queryFactory
+                .update(member)
+                .where(
+                        member.selfStudy.eq(SelfStudy.APPLIED)
+                        .or(member.selfStudy.eq(SelfStudy.CANT))
+                )
+                .set(member.selfStudy, SelfStudy.CAN)
+                .execute();
+    }
 }

--- a/src/main/java/com/server/Dotori/model/selfstudy/service/SelfStudyService.java
+++ b/src/main/java/com/server/Dotori/model/selfstudy/service/SelfStudyService.java
@@ -12,4 +12,6 @@ public interface SelfStudyService {
     void cancelSelfStudy();
 
     List<SelfStudyStudentsDto> getSelfStudyStudents();
+
+    void updateSelfStudyStatus();
 }

--- a/src/main/java/com/server/Dotori/model/selfstudy/service/SelfStudyServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/selfstudy/service/SelfStudyServiceImpl.java
@@ -57,4 +57,10 @@ public class SelfStudyServiceImpl implements SelfStudyService {
     public List<SelfStudyStudentsDto> getSelfStudyStudents() {
         return selfStudyRepository.findBySelfStudyAPLLIED();
     }
+
+    @Override
+    @Transactional
+    public void updateSelfStudyStatus() {
+        selfStudyRepository.updateSelfStudyStatus();
+    }
 }

--- a/src/test/java/com/server/Dotori/model/selfstudy/service/SelfStudyServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/selfstudy/service/SelfStudyServiceTest.java
@@ -24,9 +24,11 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.annotation.Commit;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityManager;
 import java.util.Collections;
 import java.util.List;
 
+import static com.server.Dotori.model.member.enumType.Music.APPLIED;
 import static com.server.Dotori.model.member.enumType.Music.CAN;
 import static com.server.Dotori.model.member.enumType.SelfStudy.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -39,7 +41,8 @@ class SelfStudyServiceTest {
     @Autowired private MemberRepository memberRepository;
     @Autowired private CurrentUserUtil currentUserUtil;
     @Autowired private SelfStudyService selfStudyService;
-    @Autowired private MemberService memberService;
+    @Autowired
+    EntityManager em;
 
     @BeforeEach
     @DisplayName("로그인 되어있는 유저를 확인하는 테스트")
@@ -97,5 +100,63 @@ class SelfStudyServiceTest {
 
         //then
         assertEquals(1, selfStudyStudents.size());
+    }
+
+    @Test
+    @DisplayName("학생들의 자습신청 상태가 잘 변경되나요?")
+    public void updateSelfStudyStatus() {
+        //given
+        memberRepository.save(
+                Member.builder()
+                        .username("qoxogus1")
+                        .stdNum("2410")
+                        .password("1234")
+                        .email("s20033@gsm.hs.kr")
+                        .roles(Collections.singletonList(Role.ROLE_ADMIN))
+                        .music(CAN)
+                        .selfStudy(SelfStudy.APPLIED)
+                        .point(0L)
+                        .answer("배털")
+                        .build()
+        );
+
+        memberRepository.save(
+                Member.builder()
+                        .username("qwer")
+                        .stdNum("2408")
+                        .password("1234")
+                        .email("s20031@gsm.hs.kr")
+                        .roles(Collections.singletonList(Role.ROLE_ADMIN))
+                        .music(CAN)
+                        .selfStudy(CANT)
+                        .point(0L)
+                        .answer("배털")
+                        .build()
+        );
+
+        memberRepository.save(
+                Member.builder()
+                        .username("rewq")
+                        .stdNum("2407")
+                        .password("1234")
+                        .email("s20030@gsm.hs.kr")
+                        .roles(Collections.singletonList(Role.ROLE_ADMIN))
+                        .music(CAN)
+                        .selfStudy(SelfStudy.CAN)
+                        .point(0L)
+                        .answer("배털")
+                        .build()
+        );
+
+        //when
+        selfStudyService.updateSelfStudyStatus();
+
+        em.flush();
+        em.clear();
+
+        //then
+        assertEquals(SelfStudy.CAN, memberRepository.findByUsername("qoxogus1").getSelfStudy());
+        assertEquals(SelfStudy.CAN, memberRepository.findByUsername("qwer").getSelfStudy());
+        assertEquals(SelfStudy.CAN, memberRepository.findByUsername("rewq").getSelfStudy()); //이 회원은 그대로 CAN
     }
 }

--- a/src/test/java/com/server/Dotori/model/selfstudy/service/SelfStudyServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/selfstudy/service/SelfStudyServiceTest.java
@@ -79,7 +79,7 @@ class SelfStudyServiceTest {
     public void requestSelfStudyTest() {
         selfStudyService.requestSelfStudy();
 
-        assertEquals(APPLIED, currentUserUtil.getCurrentUser().getSelfStudy());
+        assertEquals(SelfStudy.APPLIED, currentUserUtil.getCurrentUser().getSelfStudy());
     }
 
     @Test


### PR DESCRIPTION
### 제가 한 일이에요 !
* 학생들의 자습신청상태가 `신청함`, `신청취소(할수없음)` 상태일 때 
**사감쌤, 기숙사자치위원회가 버튼을 눌렀다는 가정**하에
학생들의 자습신청 상태가 `신청가능`으로 변경되는 기능을 개발했습니다
* 테스트 컨트롤러 추가
* 서비스로직 테스트코드 작성

### DB에서 확인한 결과
![스크린샷 2021-08-28 오후 8 00 19](https://user-images.githubusercontent.com/69895394/131216261-93379ecc-cd26-4da4-ba11-387ec9bec5d5.png)

> 학생들의 자습신청 상태가 `APPLIED`, `CANT`이다 
개발한 서비스 로직 수행 시 학생들의 자습신청 상태가 `CAN`으로 변경된걸 확인할 수 있다. 

![스크린샷 2021-08-28 오후 8 03 38](https://user-images.githubusercontent.com/69895394/131216258-6ad8c053-215a-4328-970e-f5dd62eec910.png)

