### PR TITLE
평일 자정 학생들의 음악신청을 변경하게 자동화

### DIFF
--- a/src/main/java/com/server/Dotori/model/music/schedule/MusicSchedule.java
+++ b/src/main/java/com/server/Dotori/model/music/schedule/MusicSchedule.java
@@ -1,25 +1,28 @@
 package com.server.Dotori.model.music.schedule;
 
 import com.server.Dotori.model.music.repository.MusicRepository;
+import com.server.Dotori.model.music.service.MusicService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Service;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class MusicSchedule {
 
     private final MusicRepository musicRepository;
-
-    public MusicSchedule(MusicRepository musicRepository) {
-        this.musicRepository = musicRepository;
-    }
+    private final MusicService musicService;
 
     @Scheduled(cron = "0 59 23 ? * SAT", zone = "GMT+9")
     public void saturdayMusicDeleteAll() {
         musicRepository.deleteAll();
+    }
+
+    @Scheduled(cron = "0 0 0 ? * MON-FRI", zone = "GMT+9")
+    public void weekdayMusicStatusReset() {
+        musicService.updateMemberMusicStatus();
     }
 
     /**

--- a/src/test/java/com/server/Dotori/model/music/schedule/MusicScheduleTest.java
+++ b/src/test/java/com/server/Dotori/model/music/schedule/MusicScheduleTest.java
@@ -20,7 +20,7 @@ class MusicScheduleTest {
     private ScheduledTaskHolder scheduledTaskHolder;
 
     @Test
-    @DisplayName("일정이 잘 예약되었는지 확인하는 테스트")
+    @DisplayName("토요일에 모든 음악이 삭제되는 일정이 잘 예약되었는지 확인하는 테스트")
     public void saturdayMusicDeleteAllTest() {
         Set<ScheduledTask> scheduledTasks = scheduledTaskHolder.getScheduledTasks();
         scheduledTasks.forEach(scheduledTask -> scheduledTask.getTask().getRunnable().getClass().getDeclaredMethods());
@@ -33,4 +33,17 @@ class MusicScheduleTest {
         Assertions.assertThat(count).isEqualTo(1L);
     }
 
+    @Test
+    @DisplayName("매일 자정에 학생들의 음악신청 상태가 '가능'으로 변경하는 일정이 잘 예약되었는지 확인하는 테스트")
+    public void weekdayMusicStatusReset() {
+        Set<ScheduledTask> scheduledTasks = scheduledTaskHolder.getScheduledTasks();
+        scheduledTasks.forEach(scheduledTask -> scheduledTask.getTask().getRunnable().getClass().getDeclaredMethods());
+
+        long count = scheduledTasks.stream()
+                .filter(scheduledTask -> scheduledTask.getTask() instanceof CronTask)
+                .map(scheduledTask -> (CronTask) scheduledTask.getTask())
+                .filter(cronTask -> cronTask.getExpression().equals("0 0 0 ? * MON-FRI") && cronTask.toString().equals("com.server.Dotori.model.music.schedule.MusicSchedule.weekdayMusicStatusReset"))
+                .count();
+        Assertions.assertThat(count).isEqualTo(1L);
+    }
 }


### PR DESCRIPTION
### 제가 한 일이에요
* 평일 자정에 학생들의 음악신청 상태가 자동으로 변경되는 기능 개발
* 일정이 예약되어있는지 테스트 코드 작성

### 🚨 @KyungJunNoh님 작업물에서 빌드가 실패합니다
<img width="725" alt="스크린샷 2021-09-04 오후 8 32 35" src="https://user-images.githubusercontent.com/69895394/132093069-3c9f0006-6129-4108-8b5f-a9e1fbddd823.png">

> 경준님 확인 후 이상없을 시 merge해주시고 build확인해주세요