### PR TITLE
자습신청 된 학생 학년반별 카테고리, 학번별 오름차순 정렬로 조회

### DIFF
--- a/src/main/java/com/server/Dotori/model/member/controller/selfstudy/SelfStudyController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/selfstudy/SelfStudyController.java
@@ -50,6 +50,16 @@ public class SelfStudyController {
         return responseService.getSingleResult(selfStudyService.getSelfStudyStudents());
     }
 
+    @GetMapping("/selfstudy/{classId}")
+    @ResponseStatus( HttpStatus.OK )
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
+    public SingleResult getSelfStudyStudentsByCategory(@PathVariable("classId") Long id) {
+        return responseService.getSingleResult(selfStudyService.getSelfStudyStudentsByCategory(id));
+    }
+
     @PutMapping ("/selfstudy/status")
     @ResponseStatus( HttpStatus.OK )
     @ApiImplicitParams({

--- a/src/main/java/com/server/Dotori/model/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/server/Dotori/model/member/repository/MemberRepositoryCustom.java
@@ -10,6 +10,8 @@ public interface MemberRepositoryCustom {
 
     List<SelfStudyStudentsDto> findBySelfStudyAPLLIED();
 
+    List<SelfStudyStudentsDto> findBySelfStudyCategory(Long id);
+
     void updateSelfStudyStatus();
 
     List<GetAboutPointDto> findStudentPoint(Long id);

--- a/src/main/java/com/server/Dotori/model/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/repository/MemberRepositoryImpl.java
@@ -21,11 +21,25 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom{
     public List<SelfStudyStudentsDto> findBySelfStudyAPLLIED() {
 
         return queryFactory.from(member)
-                .select(Projections.constructor(SelfStudyStudentsDto.class,
+                .select(Projections.fields(SelfStudyStudentsDto.class,
                         member.stdNum,
                         member.username)
                 ).where(
                         member.selfStudy.eq(SelfStudy.APPLIED)
+                )
+                .orderBy(member.stdNum.asc())
+                .fetch();
+    }
+
+    @Override
+    public List<SelfStudyStudentsDto> findBySelfStudyCategory(Long id) {
+        return queryFactory.from(member)
+                .select(Projections.constructor(SelfStudyStudentsDto.class,
+                        member.stdNum,
+                        member.username))
+                .where(
+                        member.selfStudy.eq(SelfStudy.APPLIED)
+                        .and(member.stdNum.like(id+"%"))
                 )
                 .orderBy(member.stdNum.asc())
                 .fetch();
@@ -47,7 +61,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom{
     @Override
     public List<GetAboutPointDto> findStudentPoint(Long id) {
         return queryFactory.from(member)
-                .select(Projections.constructor(GetAboutPointDto.class,
+                .select(Projections.fields(GetAboutPointDto.class,
                         member.id,
                         member.stdNum,
                         member.username,

--- a/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyService.java
+++ b/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyService.java
@@ -12,6 +12,8 @@ public interface SelfStudyService {
 
     List<SelfStudyStudentsDto> getSelfStudyStudents();
 
+    List<SelfStudyStudentsDto> getSelfStudyStudentsByCategory(Long id);
+
     void updateSelfStudyStatus();
 
     int selfStudyCount();

--- a/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
@@ -58,6 +58,15 @@ public class SelfStudyServiceImpl implements SelfStudyService {
     }
 
     @Override
+    public List<SelfStudyStudentsDto> getSelfStudyStudentsByCategory(Long id) {
+        List<SelfStudyStudentsDto> selfStudyCategory = memberRepository.findBySelfStudyCategory(id);
+
+        if (selfStudyCategory.isEmpty()) throw new IllegalArgumentException("해당 반에 해당하는 학생이 없습니다.");
+
+        return selfStudyCategory;
+    }
+
+    @Override
     @Transactional
     public void updateSelfStudyStatus() {
         memberRepository.updateSelfStudyStatus();

--- a/src/test/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceTest.java
@@ -98,6 +98,17 @@ class SelfStudyServiceTest {
     }
 
     @Test
+    @DisplayName("자습신청한 학생들의 목록이 학년반별 카테고리 목록으로 조회 되나요?")
+    public void getSelfStudyStudentsCategoryTest() {
+        //given //when
+        selfStudyService.requestSelfStudy();
+        List<SelfStudyStudentsDto> selfStudyStudentsByCategory = selfStudyService.getSelfStudyStudentsByCategory(24L);
+
+        //then
+        assertEquals(1, selfStudyStudentsByCategory.size());
+    }
+
+    @Test
     @DisplayName("학생들의 자습신청 상태가 잘 변경되나요?")
     public void updateSelfStudyStatus() {
         //given


### PR DESCRIPTION
### 제가 한 일이에요 !
* 자습신청된 학생 학년반별 카테고리, 학번별 오름차순으로 조회기능 개발
* 테스트코드 작성
* 테스트용 컨트롤러를 작성하여 테스트

> `Querydsl Projection`에서 `constructor`를 `fields`로 변경한 이유는 
**constructor는 컴파일 시점에 에러를 잡지 않고 런타임 시점에 에러를 잡기 때문**에 
**컴파일 시점에 에러를 잡는 fields로 변경**했습니다.

### 테스트하며 발견한 이슈입니다. 
🚨#81 