### PR TITLE
SelfStudy Dto idx 반환 추가

### DIFF
--- a/src/main/java/com/server/Dotori/model/member/dto/SelfStudyStudentsDto.java
+++ b/src/main/java/com/server/Dotori/model/member/dto/SelfStudyStudentsDto.java
@@ -8,10 +8,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class SelfStudyStudentsDto {
 
+    private Long id;
     private String stdNum;
     private String username;
 
-    public SelfStudyStudentsDto(String stdNum, String username) {
+    public SelfStudyStudentsDto(Long id, String stdNum, String username) {
+        this.id = id;
         this.stdNum = stdNum;
         this.username = username;
     }

--- a/src/main/java/com/server/Dotori/model/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/repository/MemberRepositoryImpl.java
@@ -35,7 +35,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom{
     @Override
     public List<SelfStudyStudentsDto> findBySelfStudyCategory(Long id) {
         return queryFactory.from(member)
-                .select(Projections.constructor(SelfStudyStudentsDto.class,
+                .select(Projections.fields(SelfStudyStudentsDto.class,
                         member.id,
                         member.stdNum,
                         member.username))
@@ -63,7 +63,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom{
     @Override
     public List<GetAboutPointDto> findStudentPoint(Long id) {
         return queryFactory.from(member)
-                .select(Projections.fields(GetAboutPointDto.class,
+                .select(Projections.constructor(GetAboutPointDto.class,
                         member.id,
                         member.stdNum,
                         member.username,

--- a/src/main/java/com/server/Dotori/model/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/repository/MemberRepositoryImpl.java
@@ -22,6 +22,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom{
 
         return queryFactory.from(member)
                 .select(Projections.fields(SelfStudyStudentsDto.class,
+                        member.id,
                         member.stdNum,
                         member.username)
                 ).where(
@@ -35,6 +36,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom{
     public List<SelfStudyStudentsDto> findBySelfStudyCategory(Long id) {
         return queryFactory.from(member)
                 .select(Projections.constructor(SelfStudyStudentsDto.class,
+                        member.id,
                         member.stdNum,
                         member.username))
                 .where(


### PR DESCRIPTION
### 제가 한 일이에요
* SelfStudy 조회건에서 id를 반환이 누락된 부분을 반환하도록 추가했습니다.

![스크린샷 2021-09-06 오후 7 01 43](https://user-images.githubusercontent.com/69895394/132199679-1c95ab61-9fee-44f3-9952-cd9dd98e25f9.png)

>  전 pr에서 잘못 적용되었던 `Querydsl Projection` `constructor`, `fields`를 재수정했습니다.
api 상황에 맞게  `constructor`, `fields`를 사용했습니다.