### PR TITLE
Feature/user 회원가입 로직 변경

### DIFF
--- a/src/main/java/com/server/Dotori/model/member/controller/MemberController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/MemberController.java
@@ -6,6 +6,8 @@ import com.server.Dotori.model.member.service.email.EmailService;
 import com.server.Dotori.model.member.service.MemberService;
 import com.server.Dotori.response.ResponseService;
 import com.server.Dotori.response.result.CommonResult;
+import io.swagger.annotations.*;
+import jdk.jfr.Event;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,9 +20,9 @@ public class MemberController {
 
     private final MemberService memberService;
     private final ResponseService responseService;
-    private final EmailService emailService;
 
     @PostMapping("/signup")
+    @ApiOperation(value="회원가입")
     public CommonResult signup(@RequestBody MemberDto memberDto){
         memberService.signup(memberDto);
         return responseService.getSuccessResult();

--- a/src/main/java/com/server/Dotori/model/member/dto/MemberDto.java
+++ b/src/main/java/com/server/Dotori/model/member/dto/MemberDto.java
@@ -4,6 +4,7 @@ import com.server.Dotori.model.member.Member;
 import com.server.Dotori.model.member.enumType.Music;
 import com.server.Dotori.model.member.enumType.Role;
 import com.server.Dotori.model.member.enumType.SelfStudy;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 
 import javax.validation.constraints.NotBlank;
@@ -18,32 +19,34 @@ import java.util.Collections;
 public class MemberDto {
     @NotBlank(message = "username should be valid")
     @Size(min = 1, max = 10)
+    @ApiModelProperty(example = "노경준")
     private String username;
 
     @NotBlank(message = "stdNum should be valid")
     @Size(min = 4, max = 4)
+    @ApiModelProperty(example = "2206")
     private String stdNum;
 
     @NotBlank(message = "password should be valid")
     @Size(min = 4)
+    @ApiModelProperty(example = "1234")
     private String password;
 
     @NotBlank(message = "email should be valid")
+    @ApiModelProperty(example = "s20018@gsm.hs.kr")
     private String email;
 
-    @NotBlank(message = "roles should be valid")
-    private String key;
-
     @NotBlank(message = "answer should be valid")
+    @ApiModelProperty(example = "노갱")
     private String answer;
 
-    public Member toEntity(Role roleAdmin){
+    public Member toEntity(){
         return Member.builder()
                 .username(username)
                 .stdNum(stdNum)
                 .password(password)
                 .email(email)
-                .roles(Collections.singletonList(roleAdmin))
+                .roles(Collections.singletonList(Role.ROLE_MEMBER))
                 .music(Music.CAN)
                 .selfStudy(SelfStudy.CAN)
                 .point(0L)

--- a/src/main/java/com/server/Dotori/model/member/dto/MemberDto.java
+++ b/src/main/java/com/server/Dotori/model/member/dto/MemberDto.java
@@ -19,25 +19,20 @@ import java.util.Collections;
 public class MemberDto {
     @NotBlank(message = "username should be valid")
     @Size(min = 1, max = 10)
-    @ApiModelProperty(example = "노경준")
     private String username;
 
     @NotBlank(message = "stdNum should be valid")
     @Size(min = 4, max = 4)
-    @ApiModelProperty(example = "2206")
     private String stdNum;
 
     @NotBlank(message = "password should be valid")
     @Size(min = 4)
-    @ApiModelProperty(example = "1234")
     private String password;
 
     @NotBlank(message = "email should be valid")
-    @ApiModelProperty(example = "s20018@gsm.hs.kr")
     private String email;
 
     @NotBlank(message = "answer should be valid")
-    @ApiModelProperty(example = "노갱")
     private String answer;
 
     public Member toEntity(){

--- a/src/main/java/com/server/Dotori/model/member/repository/MemberRepository.java
+++ b/src/main/java/com/server/Dotori/model/member/repository/MemberRepository.java
@@ -8,5 +8,4 @@ import org.springframework.stereotype.Repository;
 public interface MemberRepository extends JpaRepository<Member,Long>, MemberRepositoryCustom {
     Member findByUsername(String username);
     Member findByEmail(String email);
-    boolean existsByUsername(String username);
 }

--- a/src/main/java/com/server/Dotori/model/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/MemberServiceImpl.java
@@ -27,36 +27,16 @@ public class MemberServiceImpl implements MemberService {
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisUtil redisUtil;
 
-    @Value("${authKey.adminKey}")
-    private String adminKey;
-    @Value("${authKey.councillorKey}")
-    private String councillorKey;
-    @Value("${authKey.memberKey}")
-    private String memberKey;
-    @Value("${authKey.developerKey}")
-    private String developerKey;
-
+    /**
+     * 회원가입
+     * @param memberDto memberDto
+     * @return result.getId()
+     */
     @Override
     public Long signup(MemberDto memberDto){
-        if(memberRepository.existsByUsername(memberDto.getUsername())){
-            throw new UserNotFoundException();
-        }
         memberDto.setPassword(passwordEncoder.encode(memberDto.getPassword()));
-        if(memberDto.getKey().equals(adminKey)){
-            Member userInfo = memberRepository.save(memberDto.toEntity(ROLE_ADMIN));
-            return userInfo.getId();
-        }else if(memberDto.getKey().equals(councillorKey)){
-            Member userInfo = memberRepository.save(memberDto.toEntity(ROLE_COUNCILLOR));
-            return userInfo.getId();
-        }else if(memberDto.getKey().equals(memberKey)){
-            Member userInfo = memberRepository.save(memberDto.toEntity(ROLE_MEMBER));
-            return userInfo.getId();
-        }else if(memberDto.getKey().equals(developerKey)){
-            Member userInfo = memberRepository.save(memberDto.toEntity(ROLE_DEVELOPER));
-            return userInfo.getId();
-        }
-        Member findUser = memberRepository.findByUsername(memberDto.getUsername());
-        return findUser.getId();
+        Member result = memberRepository.save(memberDto.toEntity());
+        return result.getId();
     }
 
     @Override

--- a/src/test/java/com/server/Dotori/model/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/member/service/MemberServiceTest.java
@@ -70,16 +70,15 @@ public class MemberServiceTest {
                 .stdNum("2206")
                 .password("1234")
                 .email("s20018@gsm.hs.kr")
-                .key("ABC1")
-                .answer("hello")
+                .answer("노갱")
                 .build();
         memberDto.setPassword(passwordEncoder.encode(memberDto.getPassword()));
 
         // when
-        memberService.signup(memberDto);
+        Long result = memberService.signup(memberDto);
 
         // then
-        assertThat(memberDto.getUsername()).isEqualTo(memberRepository.findByEmail(memberDto.getEmail()).getUsername());
+        assertThat(result).isEqualTo(memberRepository.findByEmail(memberDto.getEmail()).getId());
     }
 
 }


### PR DESCRIPTION
### 제가 한일은요!
- MemberController Swagger 에서 쉽게 볼수있게 설정
<img width="281" alt="2021-09-07_18-17-35" src="https://user-images.githubusercontent.com/68670670/132319336-7a5d06a4-94e7-46b2-9e4b-533e5e91ae33.png">

- MemberDto Key 변수 삭제 및 swagger 기본 value 설정
<img width="267" alt="2021-09-07_18-16-47" src="https://user-images.githubusercontent.com/68670670/132319243-1e101426-3afb-454c-b96c-7f4f6d22f5cb.png">

- MemberRepository existsByUsername 메소드 삭제

- Update MemberServiceImpl 회원가입 로직 변경 및 주석 추가

- 회원가입 테스트코드 수정

### 모두 숙지해주셔야합니다  ⚠️
- ```MemberDto.toEntity() 의 Param```에 원래 Role을 받는 Param이 있었지만 이번 로직의 변경으로 인해 **삭제가 되었습니다** 그러므로 테스트 코드에 많은 **에러들이 속출**하고있습니다. 
각자 작성한 테스트 코드에서 toEntity 에러가 난다면 memberDto 값을 넣어주는 부분을 고쳐주시고 toEntity() Param에는 아무것도 없게 해주셔야 할것같습니다.
제 부분에서 나오는 에러들은 다음 PR때 처리할것으로 계획하고있습니다.
( + 이번 PR은 MemberDto의 변경점을 잘 보셔야할것같습니다.)

따로 Issue로 한번더 강조하도록 하겠습니다.