### PR TITLE
[FIX] 로직, 설계 변경으로 인한 오류 

### DIFF
--- a/src/test/java/com/server/Dotori/model/board/service/BoardServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/board/service/BoardServiceTest.java
@@ -59,7 +59,7 @@ class BoardServiceTest {
                 .answer("배털")
                 .build();
         memberDto.setPassword(passwordEncoder.encode(memberDto.getPassword()));
-        memberRepository.save(memberDto.toEntity(Role.ROLE_ADMIN));
+        memberRepository.save(memberDto.toEntity());
         System.out.println("======== saved =========");
 
         // when login session 발급

--- a/src/test/java/com/server/Dotori/model/member/service/email/EmailServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/member/service/email/EmailServiceTest.java
@@ -45,7 +45,6 @@ public class EmailServiceTest {
                 .stdNum("2206")
                 .password("1234")
                 .email("s20018@gsm.hs.kr")
-                .key("ABC1")
                 .answer("hello")
                 .build();
         memberDto.setPassword(passwordEncoder.encode(memberDto.getPassword()));
@@ -69,7 +68,6 @@ public class EmailServiceTest {
                 .stdNum("2206")
                 .password("1234")
                 .email("s20018@gsm.hs.kr")
-                .key("ABC1")
                 .answer("hello")
                 .build();
 

--- a/src/test/java/com/server/Dotori/model/member/service/mypage/MyPageServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/member/service/mypage/MyPageServiceTest.java
@@ -41,7 +41,7 @@ class MyPageServiceTest {
                 .answer("배털")
                 .build();
         memberDto.setPassword(passwordEncoder.encode(memberDto.getPassword()));
-        memberRepository.save(memberDto.toEntity(Role.ROLE_ADMIN));
+        memberRepository.save(memberDto.toEntity());
         System.out.println("======== saved =========");
 
         // when login session 발급

--- a/src/test/java/com/server/Dotori/model/member/service/point/PointServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/member/service/point/PointServiceTest.java
@@ -52,7 +52,7 @@ class PointServiceTest {
                 .answer("배털")
                 .build();
         memberDto.setPassword(passwordEncoder.encode(memberDto.getPassword()));
-        memberRepository.save(memberDto.toEntity(Role.ROLE_ADMIN));
+        memberRepository.save(memberDto.toEntity());
         System.out.println("======== saved =========");
 
         // when login session 발급

--- a/src/test/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceTest.java
@@ -51,7 +51,7 @@ class SelfStudyServiceTest {
                 .answer("배털")
                 .build();
         memberDto.setPassword(passwordEncoder.encode(memberDto.getPassword()));
-        memberRepository.save(memberDto.toEntity(Role.ROLE_ADMIN));
+        memberRepository.save(memberDto.toEntity());
         System.out.println("======== saved =========");
 
         // when login session 발급

--- a/src/test/java/com/server/Dotori/model/music/service/MusicServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/music/service/MusicServiceTest.java
@@ -60,7 +60,7 @@ class MusicServiceTest {
                 .answer("배털")
                 .build();
         memberDto.setPassword(passwordEncoder.encode(memberDto.getPassword()));
-        memberRepository.save(memberDto.toEntity(Role.ROLE_ADMIN));
+        memberRepository.save(memberDto.toEntity());
         System.out.println("======== saved =========");
 
         // when login session 발급

--- a/src/test/java/com/server/Dotori/security/SecurityTest.java
+++ b/src/test/java/com/server/Dotori/security/SecurityTest.java
@@ -29,7 +29,7 @@ public class SecurityTest {
         memberDto.setPassword("1234");
         memberDto.setEmail("shrudwns@naver.com");
 
-        String accessToken = jwtTokenProvider.createToken(memberDto.getUsername(), memberDto.toEntity(Role.ROLE_ADMIN).getRoles());
+        String accessToken = jwtTokenProvider.createToken(memberDto.getUsername(), memberDto.toEntity().getRoles());
         // 유효한 토큰인지 확인
         if (accessToken != null && jwtTokenProvider.validateToken(accessToken)){
             String nickname = jwtTokenProvider.getUsername(accessToken);

--- a/src/test/java/com/server/Dotori/util/CurrentUserUtilTest.java
+++ b/src/test/java/com/server/Dotori/util/CurrentUserUtilTest.java
@@ -40,7 +40,6 @@ class CurrentUserUtilTest {
                 .stdNum("2206")
                 .password("1234")
                 .email("s20018@gmail.com")
-                .key("ABC1")
                 .answer("hello")
                 .build();
         memberDto.setPassword(passwordEncoder.encode(memberDto.getPassword()));
@@ -69,7 +68,6 @@ class CurrentUserUtilTest {
                 .stdNum("2206")
                 .password("1234")
                 .email("s20018@gmail.com")
-                .key("ABC1")
                 .answer("hello")
                 .build();
         memberService.signup(memberDto);


### PR DESCRIPTION
* 회원가입 로직, 설계 변경으로 인한 오류를 모두 고쳤습니다.

> 저희 `toEntity`기본 role은 MEMBER 이지만 테스트코드에서 currentUser는 ADMIN으로 지정되어있습니다 참고바랍니다.



> 이런 오류는 한사람이 고치는게 편하고 시간적 자원도 여러명이서 하는 것 보다 적게 들기 때문에 제가 모두 고쳐버린점 이해바랍니다 🥲