### PR TITLE
학생정보 변경페이지 조회

### DIFF
--- a/src/main/java/com/server/Dotori/model/member/controller/studentinfo/StuInfoController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/studentinfo/StuInfoController.java
@@ -1,2 +1,33 @@
-package com.server.Dotori.model.member.controller.studentinfo;public class StuInfoController {
+package com.server.Dotori.model.member.controller.studentinfo;
+
+import com.server.Dotori.model.member.dto.StudentInfoDto;
+import com.server.Dotori.model.member.service.studentinfo.StuInfoService;
+import com.server.Dotori.response.ResponseService;
+import com.server.Dotori.response.result.CommonResult;
+import com.server.Dotori.response.result.SingleResult;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/member")
+@RequiredArgsConstructor
+public class StuInfoController {
+
+    private final ResponseService responseService;
+    private final StuInfoService stuInfoService;
+
+    @GetMapping ("/list/{classId}")
+    @ResponseStatus( HttpStatus.OK )
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
+    public SingleResult getStudentInfo(@PathVariable("classId") Long id) {
+        return responseService.getSingleResult(stuInfoService.getStudentInfo(id));
+    }
 }

--- a/src/main/java/com/server/Dotori/model/member/controller/studentinfo/StuInfoController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/studentinfo/StuInfoController.java
@@ -1,0 +1,2 @@
+package com.server.Dotori.model.member.controller.studentinfo;public class StuInfoController {
+}

--- a/src/main/java/com/server/Dotori/model/member/dto/StudentInfoDto.java
+++ b/src/main/java/com/server/Dotori/model/member/dto/StudentInfoDto.java
@@ -1,0 +1,18 @@
+package com.server.Dotori.model.member.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.server.Dotori.model.member.enumType.Role;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor @AllArgsConstructor
+public class StudentInfoDto {
+
+    private Long id;
+    private String stdNum;
+    private String username;
+    private List<Role> roles;
+}

--- a/src/main/java/com/server/Dotori/model/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/server/Dotori/model/member/repository/MemberRepositoryCustom.java
@@ -17,4 +17,6 @@ public interface MemberRepositoryCustom {
     List<GetAboutPointDto> findStudentPoint(Long id);
 
     GetAboutPointDto findProfileByMember(Member memberEntity);
+
+    List<Member> findStudentInfo(Long id);
 }

--- a/src/main/java/com/server/Dotori/model/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/repository/MemberRepositoryImpl.java
@@ -113,4 +113,18 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom{
                 .where(member.eq(memberEntity))
                 .fetchOne();
     }
+
+    /**
+     * 학생정보를 조회하는 query
+     * @param id classId
+     * @return List - Member
+     */
+    @Override
+    public List<Member> findStudentInfo(Long id) {
+        return queryFactory.from(member)
+                .select(member)
+                .where(member.stdNum.like(id+"%"))
+                .orderBy(member.stdNum.asc())
+                .fetch();
+    }
 }

--- a/src/main/java/com/server/Dotori/model/member/service/studentinfo/StuInfoService.java
+++ b/src/main/java/com/server/Dotori/model/member/service/studentinfo/StuInfoService.java
@@ -1,2 +1,10 @@
-package com.server.Dotori.model.member.service.studentinfo;public interface StuInfoService {
+package com.server.Dotori.model.member.service.studentinfo;
+
+import com.server.Dotori.model.member.dto.StudentInfoDto;
+
+import java.util.List;
+
+public interface StuInfoService {
+
+    List<StudentInfoDto> getStudentInfo(Long id);
 }

--- a/src/main/java/com/server/Dotori/model/member/service/studentinfo/StuInfoService.java
+++ b/src/main/java/com/server/Dotori/model/member/service/studentinfo/StuInfoService.java
@@ -1,0 +1,2 @@
+package com.server.Dotori.model.member.service.studentinfo;public interface StuInfoService {
+}

--- a/src/main/java/com/server/Dotori/model/member/service/studentinfo/StuInfoServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/studentinfo/StuInfoServiceImpl.java
@@ -1,2 +1,36 @@
-package com.server.Dotori.model.member.service.studentinfo;public class StuInfoServiceImpl {
+package com.server.Dotori.model.member.service.studentinfo;
+
+import com.server.Dotori.model.member.Member;
+import com.server.Dotori.model.member.dto.StudentInfoDto;
+import com.server.Dotori.model.member.repository.MemberRepository;
+import com.server.Dotori.util.ObjectMapperUtils;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+public class StuInfoServiceImpl implements StuInfoService {
+
+    private final MemberRepository memberRepository;
+
+    /**
+     * 학년반별로 조회한 학생들 List를 List Dto로 변경후 반환하는 서비스로직 (사감쌤, 개발자 사용가능)
+     * @param id classId
+     * @return List - StudentInfoDto (id, stuNum, username, roles)
+     */
+    @Override
+    public List<StudentInfoDto> getStudentInfo(Long id) {
+        List<Member> studentInfo = memberRepository.findStudentInfo(id);
+
+        if (studentInfo.isEmpty()) throw new IllegalArgumentException("해당 반에 해당하는 학생이 없습니다.");
+
+        return ObjectMapperUtils.mapAll(studentInfo, StudentInfoDto.class);
+    }
 }

--- a/src/main/java/com/server/Dotori/model/member/service/studentinfo/StuInfoServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/studentinfo/StuInfoServiceImpl.java
@@ -1,0 +1,2 @@
+package com.server.Dotori.model.member.service.studentinfo;public class StuInfoServiceImpl {
+}

--- a/src/main/java/com/server/Dotori/util/ObjectMapperUtils.java
+++ b/src/main/java/com/server/Dotori/util/ObjectMapperUtils.java
@@ -1,0 +1,4 @@
+package com.server.Dotori.util;
+
+public class ObjectMapperUtils {
+}

--- a/src/main/java/com/server/Dotori/util/ObjectMapperUtils.java
+++ b/src/main/java/com/server/Dotori/util/ObjectMapperUtils.java
@@ -1,4 +1,68 @@
 package com.server.Dotori.util;
 
+import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class ObjectMapperUtils {
+
+    private static ModelMapper modelMapper = new ModelMapper();
+
+    /**
+     * Model mapper property setting are specified in the following block.
+     * Default property matching strategy is set to Strict see {@link MatchingStrategies}
+     * Custom mappings are added using {@link ModelMapper#addMappings(PropertyMap)}
+     */
+    static {
+        modelMapper = new ModelMapper();
+        modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
+    }
+
+    /**
+     * Hide from public usage.
+     */
+    private ObjectMapperUtils() {
+    }
+
+    /**
+     * <p>Note: outClass object must have default constructor with no arguments</p>
+     *
+     * @param <D>      type of result object.
+     * @param <T>      type of source object to map from.
+     * @param entity   entity that needs to be mapped.
+     * @param outClass class of result object.
+     * @return new object of <code>outClass</code> type.
+     */
+    public static <D, T> D map(final T entity, Class<D> outClass) {
+        return modelMapper.map(entity, outClass);
+    }
+
+    /**
+     * <p>Note: outClass object must have default constructor with no arguments</p>
+     *
+     * @param entityList list of entities that needs to be mapped
+     * @param outCLass   class of result list element
+     * @param <D>        type of objects in result list
+     * @param <T>        type of entity in <code>entityList</code>
+     * @return list of mapped object with <code><D></code> type.
+     */
+    public static <D, T> List<D> mapAll(final Collection<T> entityList, Class<D> outCLass) {
+        return entityList.stream()
+                .map(entity -> map(entity, outCLass))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Maps {@code source} to {@code destination}.
+     *
+     * @param source      object to map from
+     * @param destination object to map to
+     */
+    public static <S, D> D map(final S source, D destination) {
+        modelMapper.map(source, destination);
+        return destination;
+    }
 }

--- a/src/test/java/com/server/Dotori/model/member/service/studentinfo/StuInfoServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/member/service/studentinfo/StuInfoServiceTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class StuInfoServiceTest {
+  
+}

--- a/src/test/java/com/server/Dotori/model/member/service/studentinfo/StuInfoServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/member/service/studentinfo/StuInfoServiceTest.java
@@ -1,4 +1,71 @@
+package com.server.Dotori.model.member.service.studentinfo;
+
+import com.server.Dotori.model.member.dto.MemberDto;
+import com.server.Dotori.model.member.dto.StudentInfoDto;
+import com.server.Dotori.model.member.enumType.Role;
+import com.server.Dotori.model.member.repository.MemberRepository;
+import com.server.Dotori.util.CurrentUserUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
 class StuInfoServiceTest {
-  
+
+    @Autowired private StuInfoService stuInfoService;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    @DisplayName("로그인 되어있는 유저를 확인하는 테스트")
+    void currentUser() {
+        //given
+        MemberDto memberDto = MemberDto.builder()
+                .username("배태현")
+                .stdNum("2409")
+                .password("0809")
+                .email("s20032@gsm.hs.kr")
+                .answer("배털")
+                .build();
+        memberDto.setPassword(passwordEncoder.encode(memberDto.getPassword()));
+        memberRepository.save(memberDto.toEntity());
+        System.out.println("======== saved =========");
+
+        // when login session 발급
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
+                memberDto.getUsername(),
+                memberDto.getPassword(),
+                List.of(new SimpleGrantedAuthority(Role.ROLE_ADMIN.name())));
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(token);
+        System.out.println("=================================");
+        System.out.println(context);
+
+        //then
+        String currentUsername = CurrentUserUtil.getCurrentUserNickname();
+        assertEquals("배태현", currentUsername);
+    }
+
+    @Test
+    @DisplayName("학년반별로 학생의 정보가 잘 조회되나요?")
+    public void getStudentInfoTest() {
+        //given //when
+        List<StudentInfoDto> studentInfo = stuInfoService.getStudentInfo(24L);
+
+        //then
+        assertEquals(1, studentInfo.size());
+    }
 }


### PR DESCRIPTION
### 제가 한 일이에요
* 학생정보 변경페이지 조회기능 개발
     * 주석작성
     * 컨트롤러를 이용하여 테스트
     * 테스트코드작성
     * ModelMapper Util class 추가 ([참고자료](https://stackoverflow.com/questions/47929674/modelmapper-mapping-list-of-entites-to-list-of-dto-objects/58324819))
     > ModelMapper를 생성자로 생성하여 dto로 변환하려 했지만 나중에 재사용성과 코드의 깔끔함을 고려하여 util class를 추가했습니다.

### 시행착오 공유
> 본 기능은 Querydsl만으로 풀리지 않는 문제여서 `Querydsl + ModelMapper`를 이용하여 문제를 해결했습니다.
Dto를 이용하여 Querydsl로 조회를 하려했지만 **조회할 Dto내에 `List형인 Role`이 있어 조회가 되지 않았습니다.**
그래서 `List-Member`형으로 조회 후 `ModelMapper`를 이용하여 `List-Dto`형으로 변환시켰습니다.

### response
> 2학년 1반으로 1명 회원가입시키고 `querystring 21`로 조회했을 때
`/v1/admin/list/21`
<img width="264" alt="스크린샷 2021-09-10 오전 10 36 57" src="https://user-images.githubusercontent.com/69895394/132789234-dbe28c88-0db9-4db4-9a9c-1a18c777d0c2.png">

> 2학년 4반으로 3명 회원가입시키고 `querystring 24`으로 조회했을 때
`/v1/admin/list/24`
<img width="433" alt="스크린샷 2021-09-10 오전 10 36 43" src="https://user-images.githubusercontent.com/69895394/132789237-7d8302c2-60de-4828-9ca6-b3c824d3ae39.png">
