### PR TITLE
권한변경

### DIFF
--- a/src/main/java/com/server/Dotori/model/member/Member.java
+++ b/src/main/java/com/server/Dotori/model/member/Member.java
@@ -118,4 +118,8 @@ public class Member implements UserDetails {
     public void updateSelfStudy(SelfStudy selfStudy) {
         this.selfStudy = selfStudy != null ? selfStudy : this.selfStudy;
     }
+
+    public void updateRole(List<Role> roles) {
+        this.roles = roles != null ? roles : this.roles;
+    }
 }

--- a/src/main/java/com/server/Dotori/model/member/controller/studentinfo/StuInfoController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/studentinfo/StuInfoController.java
@@ -38,7 +38,7 @@ public class StuInfoController {
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
-    public CommonResult getStudentInfo(@RequestBody RoleUpdateDto roleUpdateDto) {
+    public CommonResult updateRole(@RequestBody RoleUpdateDto roleUpdateDto) {
         stuInfoService.updateRole(roleUpdateDto);
         return responseService.getSuccessResult();
     }

--- a/src/main/java/com/server/Dotori/model/member/controller/studentinfo/StuInfoController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/studentinfo/StuInfoController.java
@@ -1,5 +1,6 @@
 package com.server.Dotori.model.member.controller.studentinfo;
 
+import com.server.Dotori.model.member.dto.RoleUpdateDto;
 import com.server.Dotori.model.member.dto.StudentInfoDto;
 import com.server.Dotori.model.member.service.studentinfo.StuInfoService;
 import com.server.Dotori.response.ResponseService;
@@ -29,5 +30,16 @@ public class StuInfoController {
     })
     public SingleResult getStudentInfo(@PathVariable("classId") Long id) {
         return responseService.getSingleResult(stuInfoService.getStudentInfo(id));
+    }
+
+    @PutMapping("/list/role")
+    @ResponseStatus( HttpStatus.OK )
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
+    public CommonResult getStudentInfo(@RequestBody RoleUpdateDto roleUpdateDto) {
+        stuInfoService.updateRole(roleUpdateDto);
+        return responseService.getSuccessResult();
     }
 }

--- a/src/main/java/com/server/Dotori/model/member/dto/RoleUpdateDto.java
+++ b/src/main/java/com/server/Dotori/model/member/dto/RoleUpdateDto.java
@@ -1,0 +1,2 @@
+package com.server.Dotori.model.member.dto;public class RoleUpdateDto {
+}

--- a/src/main/java/com/server/Dotori/model/member/dto/RoleUpdateDto.java
+++ b/src/main/java/com/server/Dotori/model/member/dto/RoleUpdateDto.java
@@ -1,2 +1,14 @@
-package com.server.Dotori.model.member.dto;public class RoleUpdateDto {
+package com.server.Dotori.model.member.dto;
+
+import com.server.Dotori.model.member.enumType.Role;
+import lombok.*;
+
+import java.util.List;
+
+@Getter @Setter @Builder
+@AllArgsConstructor @NoArgsConstructor
+public class RoleUpdateDto {
+
+    private Long receiverId;
+    private List<Role> roles;
 }

--- a/src/main/java/com/server/Dotori/model/member/service/studentinfo/StuInfoService.java
+++ b/src/main/java/com/server/Dotori/model/member/service/studentinfo/StuInfoService.java
@@ -1,5 +1,6 @@
 package com.server.Dotori.model.member.service.studentinfo;
 
+import com.server.Dotori.model.member.dto.RoleUpdateDto;
 import com.server.Dotori.model.member.dto.StudentInfoDto;
 
 import java.util.List;
@@ -7,4 +8,6 @@ import java.util.List;
 public interface StuInfoService {
 
     List<StudentInfoDto> getStudentInfo(Long id);
+
+    void updateRole(RoleUpdateDto roleUpdateDto);
 }

--- a/src/main/java/com/server/Dotori/model/member/service/studentinfo/StuInfoServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/studentinfo/StuInfoServiceImpl.java
@@ -1,14 +1,25 @@
 package com.server.Dotori.model.member.service.studentinfo;
 
+import com.server.Dotori.exception.user.exception.UserNotFoundException;
 import com.server.Dotori.model.member.Member;
+import com.server.Dotori.model.member.dto.RoleUpdateDto;
 import com.server.Dotori.model.member.dto.StudentInfoDto;
+import com.server.Dotori.model.member.enumType.Role;
 import com.server.Dotori.model.member.repository.MemberRepository;
+import com.server.Dotori.util.CurrentUserUtil;
 import com.server.Dotori.util.ObjectMapperUtils;
+import com.server.Dotori.util.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -19,6 +30,7 @@ import java.util.stream.Stream;
 public class StuInfoServiceImpl implements StuInfoService {
 
     private final MemberRepository memberRepository;
+    private final RedisUtil redisUtil;
 
     /**
      * 학년반별로 조회한 학생들 List를 List Dto로 변경후 반환하는 서비스로직 (사감쌤, 개발자 사용가능)
@@ -32,5 +44,31 @@ public class StuInfoServiceImpl implements StuInfoService {
         if (studentInfo.isEmpty()) throw new IllegalArgumentException("해당 반에 해당하는 학생이 없습니다.");
 
         return ObjectMapperUtils.mapAll(studentInfo, StudentInfoDto.class);
+    }
+
+    /**
+     * 권한을 업데이트하는 서비스로직 (사감쌤, 개발자 사용가능)
+     * 권한이 업데이트된 사용자는 로그인을 다시 해야한다. (공지를 해야할듯)
+     * @param roleUpdateDto (receiverId, roles)
+     */
+    @Override
+    @Transactional
+    public void updateRole(RoleUpdateDto roleUpdateDto) {
+        Member member = memberRepository.findById(roleUpdateDto.getReceiverId())
+                .orElseThrow(() -> new UserNotFoundException());
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication(); //기존 계정의 권한정보를 가지고온다.
+        List<GrantedAuthority> updatedAuthorities = new ArrayList<>(auth.getAuthorities());
+
+        updatedAuthorities.add(new SimpleGrantedAuthority(roleUpdateDto.getRoles().toString())); //변경시켜줄 권한 추가
+
+        Authentication newAuth = new UsernamePasswordAuthenticationToken(
+                auth.getPrincipal(), auth.getCredentials(), updatedAuthorities //추가한 권한정보로 다시 Security가 관리할 수 있는 객체 생성
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(newAuth); // Security가 관리하고있는 객체를 변경된 대상으로 변경
+
+        member.updateRole(roleUpdateDto.getRoles());
+        redisUtil.deleteData(member.getEmail()); //다시 로그인을 시켜야하기 때문에 refreshtoken을 미리 지워둔다.
     }
 }

--- a/src/test/java/com/server/Dotori/model/member/service/studentinfo/StuInfoServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/member/service/studentinfo/StuInfoServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityManager;
 import java.util.Collections;
 import java.util.List;
 
@@ -30,6 +31,8 @@ class StuInfoServiceTest {
     @Autowired private StuInfoService stuInfoService;
     @Autowired private MemberRepository memberRepository;
     @Autowired private PasswordEncoder passwordEncoder;
+    @Autowired private CurrentUserUtil currentUserUtil;
+    @Autowired private EntityManager em;
 
     @BeforeEach
     @DisplayName("로그인 되어있는 유저를 확인하는 테스트")
@@ -77,10 +80,13 @@ class StuInfoServiceTest {
         //given //when
         stuInfoService.updateRole(
                 RoleUpdateDto.builder()
-                        .receiverId(1L)
+                        .receiverId(currentUserUtil.getCurrentUser().getId())
                         .roles(Collections.singletonList(Role.ROLE_COUNCILLOR))
                         .build()
         );
+
+        em.flush();
+        em.clear();
 
         //then
         assertEquals(memberRepository.findByUsername("배태현").getRoles().toString(), Collections.singletonList(Role.ROLE_COUNCILLOR).toString());

--- a/src/test/java/com/server/Dotori/model/member/service/studentinfo/StuInfoServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/member/service/studentinfo/StuInfoServiceTest.java
@@ -1,6 +1,7 @@
 package com.server.Dotori.model.member.service.studentinfo;
 
 import com.server.Dotori.model.member.dto.MemberDto;
+import com.server.Dotori.model.member.dto.RoleUpdateDto;
 import com.server.Dotori.model.member.dto.StudentInfoDto;
 import com.server.Dotori.model.member.enumType.Role;
 import com.server.Dotori.model.member.repository.MemberRepository;
@@ -17,6 +18,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -67,5 +69,20 @@ class StuInfoServiceTest {
 
         //then
         assertEquals(1, studentInfo.size());
+    }
+
+    @Test
+    @DisplayName("권한이 제대로 변경되나요?")
+    public void updateRole() {
+        //given //when
+        stuInfoService.updateRole(
+                RoleUpdateDto.builder()
+                        .receiverId(1L)
+                        .roles(Collections.singletonList(Role.ROLE_COUNCILLOR))
+                        .build()
+        );
+
+        //then
+        assertEquals(memberRepository.findByUsername("배태현").getRoles().toString(), Collections.singletonList(Role.ROLE_COUNCILLOR).toString());
     }
 }


### PR DESCRIPTION
### 제가 한 일이에요 
* 권한변경 서비스로직 추가
* 테스트용 컨트롤러 추가 후 테스트
* 테스트코드 작성

`SecurityContextHolder.getContext().getAuthentication().getAuthorities()` 를 이용하여 
print를 찍은 결과입니다. (시큐리티 컨텍스트에 올라가있는 권한)
`ROLE_MEMBER` -> `ROLE_COUNCILLOR`로 제대로 변경된 것을 확인할 수 있습니다.

<img width="154" alt="스크린샷 2021-09-13 오후 5 04 17" src="https://user-images.githubusercontent.com/69895394/133048451-b92f3c8f-54ea-4676-b485-cb35faeaccba.png">

<img width="205" alt="스크린샷 2021-09-13 오후 5 04 35" src="https://user-images.githubusercontent.com/69895394/133048448-5eb7707a-f1d1-4394-a26f-39dd53e12535.png">

슬랙에 올렸 듯 저희 Dotori는 인증방식을
세션방식이 아니라 JWT 방식을 사용하므로 권한 변경된 유저는 다시 로그인해야합니다.
> 권한이 변경되기 전 토큰에 있는 권한 정보를 새로 부여받은 권한 정보로 토큰을 재 발급받기 위함

> 권한을 변경시키거나 하는 경우는 1년에 약 1번정도밖에 없으니
"도토리 공지사항 기능을 이용해 새로 선발된 기숙사 자치위원들은 Dotori 웹 사이트를 로그아웃 하고 다시 로그인 해주시길 바랍니다."
이런 방식으로 공지하는 방법도 괜찮은 것 같습니다.

---
권한 변경 이후 다시 로그인하고 요청을 보내고
시큐리티 컨텍스트에서 권한을 찍어보면 제대로 변경된 권한이 찍히지만 
권한별 url 접근은 제대로 확인하지 못하였습니다. 
모든 개발을 완료한 뒤 다시 테스트해봐야 할 것 같습니다. (제대로 확인이 안되는 듯 해서)

권한 변경이후 권한에 맞게 url에 접근이 되지 않는다면 권한쪽 로직을 변경해야할 것 같습니다. (다른 방법으로 계속 시도중임)
> 예를 들어 회원가입 때 권한 선택을 한다던지..