### PR TITLE
AuthPassword 로직 수정 + User, Refresh, ServiceImpl 주석 추가

### DIFF
--- a/src/main/java/com/server/Dotori/model/member/controller/Email/EmailController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/Email/EmailController.java
@@ -1,5 +1,6 @@
 package com.server.Dotori.model.member.controller.Email;
 
+import com.server.Dotori.model.member.dto.AuthPasswordDto;
 import com.server.Dotori.model.member.dto.EmailDto;
 import com.server.Dotori.model.member.dto.MemberEmailKeyDto;
 import com.server.Dotori.model.member.service.email.EmailService;
@@ -32,8 +33,8 @@ public class EmailController {
     }
 
     @PostMapping("/auth/password")
-    public CommonResult authPassword(@RequestBody EmailDto emailDto){
-        emailService.authPassword(emailDto);
+    public CommonResult authPassword(@RequestBody AuthPasswordDto authPasswordDto){
+        emailService.authPassword(authPasswordDto);
         return responseService.getSuccessResult();
     }
 }

--- a/src/main/java/com/server/Dotori/model/member/controller/Email/EmailController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/Email/EmailController.java
@@ -45,7 +45,7 @@ public class EmailController {
     }
 
     /**
-     * 이메일 임시 비밀번호 Controller
+     * 이메일로 임시 비밀번호을 발급해주는 Controller
      * @param authPasswordDto email, password
      * @return SuccessResult
      * @author 노경준

--- a/src/main/java/com/server/Dotori/model/member/controller/Email/EmailController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/Email/EmailController.java
@@ -20,18 +20,36 @@ public class EmailController {
     private final EmailService emailService;
     private final ResponseService responseService;
 
+    /**
+     * 이메일 인증 Controller
+     * @param emailDto email
+     * @return SuccessResult
+     * @author 노경준
+     */
     @PostMapping("/auth")
     public CommonResult authKey(@RequestBody EmailDto emailDto){
         emailService.authKey(emailDto);
         return responseService.getSuccessResult();
     }
 
+    /**
+     * 이메일 인증 확인 Controller
+     * @param memberEmailKeyDto key
+     * @return SuccessResult
+     * @author 노경준
+     */
     @PostMapping("/auth/check")
     public CommonResult authCheck(@RequestBody MemberEmailKeyDto memberEmailKeyDto){
         emailService.authCheck(memberEmailKeyDto);
         return responseService.getSuccessResult();
     }
 
+    /**
+     * 이메일 임시 비밀번호 Controller
+     * @param authPasswordDto email, password
+     * @return SuccessResult
+     * @author 노경준
+     */
     @PostMapping("/auth/password")
     public CommonResult authPassword(@RequestBody AuthPasswordDto authPasswordDto){
         emailService.authPassword(authPasswordDto);

--- a/src/main/java/com/server/Dotori/model/member/controller/MemberController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/MemberController.java
@@ -23,6 +23,12 @@ public class MemberController {
     private final MemberService memberService;
     private final ResponseService responseService;
 
+    /**
+     * 회원가입 Controller
+     * @param memberDto username, stdNum, password, email, answer
+     * @return SuccessResult
+     * @author 노경준
+     */
     @PostMapping("/signup")
     @ApiOperation(value="회원가입")
     public CommonResult signup(@RequestBody MemberDto memberDto){
@@ -30,6 +36,12 @@ public class MemberController {
         return responseService.getSuccessResult();
     }
 
+    /**
+     * 로그인 Controller
+     * @param memberLoginDto email, password
+     * @return SingleResult(data)
+     * @author 노경준
+     */
     @PostMapping("/signin")
     @ApiOperation(value="로그인")
     public CommonResult signin(@RequestBody MemberLoginDto memberLoginDto){
@@ -37,6 +49,12 @@ public class MemberController {
         return responseService.getSingleResult(data);
     }
 
+    /**
+     * 비밀번호 변경 Controller
+     * @param memberPasswordDto oldPassword, newPassword
+     * @return SingleResult(data)
+     * @author 노경준
+     */
     @PostMapping("/change/password")
     @ApiOperation(value="비밀번호 변경")
     @ApiImplicitParams({
@@ -48,7 +66,11 @@ public class MemberController {
         return responseService.getSingleResult(data);
     }
 
-
+    /**
+     * 로그아웃 Controller
+     * @return SuccessResult
+     * @author 노경준
+     */
     @DeleteMapping("/logout")
     @ApiOperation(value="로그아웃")
     @ApiImplicitParams({
@@ -59,6 +81,12 @@ public class MemberController {
         return responseService.getSuccessResult();
     }
 
+    /**
+     * 회원탈퇴 Controller
+     * @param memberDeleteDto username, password
+     * @return SuccessResult
+     * @author 노경준
+     */
     @PostMapping("/delete")
     @ApiOperation(value="회원탈퇴")
     @ApiImplicitParams({

--- a/src/main/java/com/server/Dotori/model/member/controller/MemberController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import com.server.Dotori.model.member.service.email.EmailService;
 import com.server.Dotori.model.member.service.MemberService;
 import com.server.Dotori.response.ResponseService;
 import com.server.Dotori.response.result.CommonResult;
+import com.server.Dotori.response.result.SingleResult;
 import io.swagger.annotations.*;
 import jdk.jfr.Event;
 import lombok.RequiredArgsConstructor;
@@ -44,7 +45,7 @@ public class MemberController {
      */
     @PostMapping("/signin")
     @ApiOperation(value="로그인")
-    public CommonResult signin(@RequestBody MemberLoginDto memberLoginDto){
+    public SingleResult<Map<String, String>> signin(@RequestBody MemberLoginDto memberLoginDto){
         Map<String, String> data = memberService.signin(memberLoginDto);
         return responseService.getSingleResult(data);
     }
@@ -61,7 +62,7 @@ public class MemberController {
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
-    public CommonResult passwordChange(@RequestBody MemberPasswordDto memberPasswordDto){
+    public SingleResult<Map<String, String>> passwordChange(@RequestBody MemberPasswordDto memberPasswordDto){
         Map<String,String> data = memberService.passwordChange(memberPasswordDto);
         return responseService.getSingleResult(data);
     }

--- a/src/main/java/com/server/Dotori/model/member/controller/MemberController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/MemberController.java
@@ -39,7 +39,7 @@ public class MemberController {
     /**
      * 로그인 Controller
      * @param memberLoginDto email, password
-     * @return SingleResult(data)
+     * @return SingleResult
      * @author 노경준
      */
     @PostMapping("/signin")
@@ -52,7 +52,7 @@ public class MemberController {
     /**
      * 비밀번호 변경 Controller
      * @param memberPasswordDto oldPassword, newPassword
-     * @return SingleResult(data)
+     * @return SingleResult
      * @author 노경준
      */
     @PostMapping("/change/password")

--- a/src/main/java/com/server/Dotori/model/member/controller/RefreshTokenController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/RefreshTokenController.java
@@ -3,6 +3,7 @@ package com.server.Dotori.model.member.controller;
 import com.server.Dotori.model.member.service.RefreshTokenService;
 import com.server.Dotori.response.ResponseService;
 import com.server.Dotori.response.result.CommonResult;
+import com.server.Dotori.response.result.SingleResult;
 import com.server.Dotori.security.jwt.JwtTokenProvider;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
@@ -37,7 +38,7 @@ public class RefreshTokenController {
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
-    public CommonResult refresh(HttpServletRequest request){
+    public SingleResult<Map<String, String>> refresh(HttpServletRequest request){
         Map<String, String> data = refreshTokenService.getRefreshToken(request.getRemoteUser(), jwtTokenProvider.resolveRefreshToken(request));
         return responseService.getSingleResult(data);
     }

--- a/src/main/java/com/server/Dotori/model/member/controller/RefreshTokenController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/RefreshTokenController.java
@@ -28,7 +28,7 @@ public class RefreshTokenController {
     /**
      * 토큰 재발급 Controller
      * @param request accessToken, refreshToken
-     * @return SuccessResult
+     * @return SingleResult
      * @author 노경준
      */
     @GetMapping("/refresh")

--- a/src/main/java/com/server/Dotori/model/member/controller/RefreshTokenController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/RefreshTokenController.java
@@ -3,6 +3,7 @@ package com.server.Dotori.model.member.controller;
 import com.server.Dotori.model.member.service.RefreshTokenService;
 import com.server.Dotori.response.ResponseService;
 import com.server.Dotori.response.result.CommonResult;
+import com.server.Dotori.security.jwt.JwtTokenProvider;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +23,7 @@ public class RefreshTokenController {
 
     private final RefreshTokenService refreshTokenService;
     private final ResponseService responseService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     /**
      * 토큰 재발급 Controller
@@ -35,8 +38,8 @@ public class RefreshTokenController {
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
     public CommonResult refresh(HttpServletRequest request){
-        refreshTokenService.getRefreshToken(request);
-        return responseService.getSuccessResult();
+        Map<String, String> data = refreshTokenService.getRefreshToken(request.getRemoteUser(), jwtTokenProvider.resolveRefreshToken(request));
+        return responseService.getSingleResult(data);
     }
 
 }

--- a/src/main/java/com/server/Dotori/model/member/controller/RefreshTokenController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/RefreshTokenController.java
@@ -22,6 +22,12 @@ public class RefreshTokenController {
     private final RefreshTokenService refreshTokenService;
     private final ResponseService responseService;
 
+    /**
+     * 토큰 재발급 Controller
+     * @param request accessToken, refreshToken
+     * @return SuccessResult
+     * @author 노경준
+     */
     @GetMapping("/refresh")
     @ResponseStatus( HttpStatus.OK )
     @ApiImplicitParams({

--- a/src/main/java/com/server/Dotori/model/member/dto/AuthPasswordDto.java
+++ b/src/main/java/com/server/Dotori/model/member/dto/AuthPasswordDto.java
@@ -1,0 +1,11 @@
+package com.server.Dotori.model.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AuthPasswordDto {
+    private String email;
+    private String answer;
+}

--- a/src/main/java/com/server/Dotori/model/member/dto/EmailDto.java
+++ b/src/main/java/com/server/Dotori/model/member/dto/EmailDto.java
@@ -6,5 +6,5 @@ import lombok.Setter;
 @Getter
 @Setter
 public class EmailDto {
-    private String userEmail;
+    private String email;
 }

--- a/src/main/java/com/server/Dotori/model/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/MemberServiceImpl.java
@@ -36,8 +36,9 @@ public class MemberServiceImpl implements MemberService {
 
     /**
      * 회원가입
-     * @param memberDto memberDto
+     * @param memberDto username, stdNum, password, email, answer
      * @return result.getId()
+     * @author 노경준
      */
     @Override
     public Long signup(MemberDto memberDto){
@@ -52,8 +53,9 @@ public class MemberServiceImpl implements MemberService {
 
     /**
      * 로그인
-     * @param memberLoginDto memberLoginDto
-     * @return
+     * @param memberLoginDto email, password
+     * @return map - username, accessToken, refreshToken
+     * @author 노경준
      */
     @Override
     public Map<String,String> signin(MemberLoginDto memberLoginDto) {
@@ -79,9 +81,10 @@ public class MemberServiceImpl implements MemberService {
     }
 
     /**
-     * 로그되어있을 때 사용가능
-     * @param memberPasswordDto memberPasswordDto
-     * @return
+     * 로그인 되어있을 때 사용가능
+     * @param memberPasswordDto oldPassword, newPassword
+     * @return map - username
+     * @author 노경준
      */
     @Transactional
     @Override
@@ -98,11 +101,20 @@ public class MemberServiceImpl implements MemberService {
         return map;
     }
 
+    /**
+     * 로그아웃
+     * @author 노경준
+     */
     @Override
     public void logout() {
         redisUtil.deleteData(currentUserUtil.getCurrentUser().getUsername());
     }
 
+    /**
+     * 회원탈퇴
+     * @param memberDeleteDto username, password
+     * @author 노경준
+     */
     @Override
     public void delete(MemberDeleteDto memberDeleteDto) {
         Member findMember = memberRepository.findByUsername(memberDeleteDto.getUsername());

--- a/src/main/java/com/server/Dotori/model/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/MemberServiceImpl.java
@@ -35,7 +35,7 @@ public class MemberServiceImpl implements MemberService {
     private final CurrentUserUtil currentUserUtil;
 
     /**
-     * 회원가입
+     * 회원가입하는 서비스 로직
      * @param memberDto username, stdNum, password, email, answer
      * @return result.getId()
      * @author 노경준
@@ -52,7 +52,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     /**
-     * 로그인
+     * 로그인하는 서비스 로직
      * @param memberLoginDto email, password
      * @return map - username, accessToken, refreshToken
      * @author 노경준
@@ -81,7 +81,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     /**
-     * 로그인 되어있을 때 비밀번호 변경
+     * 로그인 되어있을 때 비밀번호 변경하는 서비스 로직
      * @param memberPasswordDto oldPassword, newPassword
      * @return map - username
      * @author 노경준
@@ -102,7 +102,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     /**
-     * 로그아웃
+     * 로그아웃 하는 서비스 로직
      * @author 노경준
      */
     @Override
@@ -111,7 +111,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     /**
-     * 회원탈퇴
+     * 회원탈퇴 하는 서비스 로직
      * @param memberDeleteDto username, password
      * @author 노경준
      */

--- a/src/main/java/com/server/Dotori/model/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/MemberServiceImpl.java
@@ -81,7 +81,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     /**
-     * 로그인 되어있을 때 사용가능
+     * 로그인 되어있을 때 비밀번호 변경
      * @param memberPasswordDto oldPassword, newPassword
      * @return map - username
      * @author 노경준

--- a/src/main/java/com/server/Dotori/model/member/service/RefreshTokenService.java
+++ b/src/main/java/com/server/Dotori/model/member/service/RefreshTokenService.java
@@ -4,5 +4,5 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.Map;
 
 public interface RefreshTokenService {
-    Map<String,String> getRefreshToken(HttpServletRequest request);
+    Map<String,String> getRefreshToken(String username, String token);
 }

--- a/src/main/java/com/server/Dotori/model/member/service/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/RefreshTokenServiceImpl.java
@@ -29,18 +29,16 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
 
     /**
      * 토큰 재발급
-     * @param request accessToken
+     * @param username username
+     * @param refreshToken refreshToken
      * @return map - username, accessToken, refreshToken
      * @author 노경준
      */
     @Override
-    public Map<String, String> getRefreshToken(HttpServletRequest request) {
+    public Map<String, String> getRefreshToken(String username, String refreshToken) {
+        Member findMember = memberRepository.findByUsername(username);
+        List<Role> roles = findMember.getRoles();
 
-        String accessToken = jwtTokenProvider.resolveToken(request);
-        String refreshToken = jwtTokenProvider.resolveRefreshToken(request);
-        String username = jwtTokenProvider.getUsername(accessToken);
-        Member memberInfo = memberRepository.findByUsername(username);
-        List<Role> roles = memberInfo.getRoles();
         Map<String,String> map = new HashMap<>();
         String newAccessToken = null;
         String newRefreshToken = null;

--- a/src/main/java/com/server/Dotori/model/member/service/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/RefreshTokenServiceImpl.java
@@ -28,7 +28,7 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
     private final RedisUtil redisUtil;
 
     /**
-     * 토큰 재발급
+     * RefreshToken으로 AccessToken과 RefreshToken을 재발급 시켜주는 서비스 로직
      * @param username username
      * @param refreshToken refreshToken
      * @return map - username, accessToken, refreshToken

--- a/src/main/java/com/server/Dotori/model/member/service/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/RefreshTokenServiceImpl.java
@@ -27,6 +27,12 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
     private final MemberRepository memberRepository;
     private final RedisUtil redisUtil;
 
+    /**
+     * 토큰 재발급
+     * @param request accessToken
+     * @return map - username, accessToken, refreshToken
+     * @author 노경준
+     */
     @Override
     public Map<String, String> getRefreshToken(HttpServletRequest request) {
 
@@ -55,6 +61,6 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
             return map;
         }
 
-        return map;
+        throw new IllegalArgumentException("토큰 재발급에 실패했습니다.");
     }
 }

--- a/src/main/java/com/server/Dotori/model/member/service/email/EmailSendService.java
+++ b/src/main/java/com/server/Dotori/model/member/service/email/EmailSendService.java
@@ -3,6 +3,6 @@ package com.server.Dotori.model.member.service.email;
 import com.server.Dotori.model.member.dto.EmailDto;
 
 public interface EmailSendService {
-    void sendEmail(String userEmail,String key);
-    void sendPasswordEmail(String userEmail, String password);
+    void sendEmail(String email,String key);
+    void sendPasswordEmail(String email, String password);
 }

--- a/src/main/java/com/server/Dotori/model/member/service/email/EmailSendServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/email/EmailSendServiceImpl.java
@@ -13,7 +13,7 @@ public class EmailSendServiceImpl implements EmailSendService {
     private final MailSender mailSender;
 
     /**
-     * 인증 키 보내기
+     * 이메일로 인증키를 보내주는 서비스 로직
      * @param email email
      * @param key key
      * @author 노경준
@@ -28,7 +28,7 @@ public class EmailSendServiceImpl implements EmailSendService {
     }
 
     /**
-     * 임시 비밀번호 발급
+     * 이메일로 임시 비밀번호를 전송하는 서비스 로직
      * @param email email
      * @param password password
      * @author 노경준

--- a/src/main/java/com/server/Dotori/model/member/service/email/EmailSendServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/email/EmailSendServiceImpl.java
@@ -11,6 +11,13 @@ import org.springframework.stereotype.Service;
 public class EmailSendServiceImpl implements EmailSendService {
 
     private final MailSender mailSender;
+
+    /**
+     * 인증 키 보내기
+     * @param userEmail 이메일
+     * @param key 인증키
+     * @author 노경준
+     */
     @Override
     public void sendEmail(String userEmail, String key) {
         SimpleMailMessage message = new SimpleMailMessage();
@@ -20,6 +27,12 @@ public class EmailSendServiceImpl implements EmailSendService {
         mailSender.send(message);
     }
 
+    /**
+     * 임시 비밀번호 발급
+     * @param userEmail 이메일
+     * @param password 현재 비밀번호
+     * @author 노경준
+     */
     @Override
     public void sendPasswordEmail(String userEmail, String password) {
         SimpleMailMessage message = new SimpleMailMessage();

--- a/src/main/java/com/server/Dotori/model/member/service/email/EmailSendServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/email/EmailSendServiceImpl.java
@@ -14,14 +14,14 @@ public class EmailSendServiceImpl implements EmailSendService {
 
     /**
      * 인증 키 보내기
-     * @param userEmail 이메일
-     * @param key 인증키
+     * @param email email
+     * @param key key
      * @author 노경준
      */
     @Override
-    public void sendEmail(String userEmail, String key) {
+    public void sendEmail(String email, String key) {
         SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(userEmail);
+        message.setTo(email);
         message.setSubject("[DOTORI] 인증 키");
         message.setText("DOTORI 에서 보낸 인증 키 : " + key);
         mailSender.send(message);
@@ -29,14 +29,14 @@ public class EmailSendServiceImpl implements EmailSendService {
 
     /**
      * 임시 비밀번호 발급
-     * @param userEmail 이메일
-     * @param password 현재 비밀번호
+     * @param email email
+     * @param password password
      * @author 노경준
      */
     @Override
-    public void sendPasswordEmail(String userEmail, String password) {
+    public void sendPasswordEmail(String email, String password) {
         SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(userEmail);
+        message.setTo(email);
         message.setSubject("[DOTORI] 임시 비밀번호");
         message.setText("DOTORI 에서 보낸 임시 비밀번호 : " + password);
         mailSender.send(message);

--- a/src/main/java/com/server/Dotori/model/member/service/email/EmailService.java
+++ b/src/main/java/com/server/Dotori/model/member/service/email/EmailService.java
@@ -1,11 +1,12 @@
 package com.server.Dotori.model.member.service.email;
 
 import com.server.Dotori.model.member.Member;
+import com.server.Dotori.model.member.dto.AuthPasswordDto;
 import com.server.Dotori.model.member.dto.EmailDto;
 import com.server.Dotori.model.member.dto.MemberEmailKeyDto;
 
 public interface EmailService {
     String authKey(EmailDto emailDto);
     String authCheck(MemberEmailKeyDto memberEmailKeyDto);
-    Member authPassword(EmailDto emailDto);
+    Member authPassword(AuthPasswordDto authPasswordDto);
 }

--- a/src/main/java/com/server/Dotori/model/member/service/email/EmailServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/email/EmailServiceImpl.java
@@ -26,7 +26,7 @@ public class EmailServiceImpl implements EmailService {
     private final PasswordEncoder passwordEncoder;
 
     /**
-     * 이메일로 인증하기 유저의 이메일을 받아서 받은 이메일 주소로 인증번호를 보내주는 기능
+     * 유저의 이메일을 받아서 받은 이메일 주소로 인증번호를 보내주는 기능
      * @param emailDto email
      * @return 인증번호
      * @author 노경준
@@ -56,9 +56,9 @@ public class EmailServiceImpl implements EmailService {
     }
 
     /**
-     * 로그인 안했을때 사용할 수 있는 기능
+     * 로그인 안했을때 비밀번호를 변경하는 서비스 로직
      * @param authPasswordDto email, answer
-     * @return Member
+     * @return findMember
      * @author 노경준
      */
     @Transactional

--- a/src/main/java/com/server/Dotori/model/member/service/email/EmailServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/email/EmailServiceImpl.java
@@ -2,6 +2,7 @@ package com.server.Dotori.model.member.service.email;
 
 import com.server.Dotori.exception.user.exception.UserNotFoundException;
 import com.server.Dotori.model.member.Member;
+import com.server.Dotori.model.member.dto.AuthPasswordDto;
 import com.server.Dotori.model.member.dto.EmailDto;
 import com.server.Dotori.model.member.dto.MemberEmailKeyDto;
 import com.server.Dotori.model.member.repository.MemberRepository;
@@ -55,18 +56,19 @@ public class EmailServiceImpl implements EmailService {
 
     /**
      * 로그인 안했을때 사용할 수 있는 기능
-     * @param emailDto
+     * @param authPasswordDto
      * @return Member
      */
     @Transactional
     @Override
-    public Member authPassword(EmailDto emailDto) {
-        String email = emailDto.getUserEmail();
+    public Member authPassword(AuthPasswordDto authPasswordDto) {
+        String email = authPasswordDto.getEmail();
+        Member findMember = memberRepository.findByEmail(authPasswordDto.getEmail());
+        if(findMember == null) throw new UserNotFoundException();
+        if(!findMember.getAnswer().equals(authPasswordDto.getAnswer())) throw new IllegalArgumentException("질문 답이 일치하지 않습니다.");
+
         String password = getTempPassword();
         emailSendService.sendPasswordEmail(email,password);
-
-        Member findMember = memberRepository.findByEmail(emailDto.getUserEmail());
-        if(findMember == null) throw new UserNotFoundException();
 
         findMember.updatePassword(passwordEncoder.encode(password));
 

--- a/src/main/java/com/server/Dotori/model/member/service/email/EmailServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/email/EmailServiceImpl.java
@@ -24,25 +24,26 @@ public class EmailServiceImpl implements EmailService {
     private final RedisUtil redisUtil;
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
-    private final CurrentUserUtil currentUserUtil;
 
     /**
      * 이메일로 인증하기 유저의 이메일을 받아서 받은 이메일 주소로 인증번호를 보내주는 기능
-     * @param emailDto
+     * @param emailDto email
      * @return 인증번호
+     * @author 노경준
      */
     @Override
     public String authKey(EmailDto emailDto) {
         String key = keyUtil.keyIssuance();
         redisUtil.setDataExpire(key, key, 3 * 60 * 1000L);
-        emailSendService.sendEmail(emailDto.getUserEmail(),key);
+        emailSendService.sendEmail(emailDto.getEmail(),key);
         return key;
     }
 
     /**
      * authKey 기능에서 받은 키를 확인(인증)하는 기능
-     * @param memberEmailKeyDto
+     * @param memberEmailKeyDto key
      * @return 입력된 키
+     * @author 노경준
      */
     @Override
     public String authCheck(MemberEmailKeyDto memberEmailKeyDto) {
@@ -56,8 +57,9 @@ public class EmailServiceImpl implements EmailService {
 
     /**
      * 로그인 안했을때 사용할 수 있는 기능
-     * @param authPasswordDto
+     * @param authPasswordDto email, answer
      * @return Member
+     * @author 노경준
      */
     @Transactional
     @Override

--- a/src/test/java/com/server/Dotori/model/member/service/email/EmailServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/member/service/email/EmailServiceTest.java
@@ -62,7 +62,7 @@ public class EmailServiceTest {
         memberDto.setPassword(passwordEncoder.encode(memberDto.getPassword()));
 
         EmailDto emailDto = new EmailDto();
-        emailDto.setUserEmail(memberDto.getEmail());
+        emailDto.setEmail(memberDto.getEmail());
 
         //when
         String key = emailService.authKey(emailDto);

--- a/src/test/java/com/server/Dotori/model/member/service/email/EmailServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/member/service/email/EmailServiceTest.java
@@ -1,22 +1,34 @@
 package com.server.Dotori.model.member.service.email;
 
 import com.server.Dotori.model.member.Member;
+import com.server.Dotori.model.member.dto.AuthPasswordDto;
 import com.server.Dotori.model.member.dto.EmailDto;
 import com.server.Dotori.model.member.dto.MemberDto;
+import com.server.Dotori.model.member.enumType.Role;
 import com.server.Dotori.model.member.repository.MemberRepository;
 import com.server.Dotori.model.member.service.MemberService;
 import com.server.Dotori.model.member.service.email.EmailService;
+import com.server.Dotori.util.CurrentUserUtil;
 import com.server.Dotori.util.redis.RedisUtil;
 
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.transaction.Transactional;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @Transactional
@@ -45,7 +57,7 @@ public class EmailServiceTest {
                 .stdNum("2206")
                 .password("1234")
                 .email("s20018@gsm.hs.kr")
-                .answer("hello")
+                .answer("노갱")
                 .build();
         memberDto.setPassword(passwordEncoder.encode(memberDto.getPassword()));
 
@@ -68,15 +80,16 @@ public class EmailServiceTest {
                 .stdNum("2206")
                 .password("1234")
                 .email("s20018@gsm.hs.kr")
-                .answer("hello")
+                .answer("노갱")
                 .build();
 
-        EmailDto emailDto = new EmailDto();
-        emailDto.setUserEmail(memberDto.getEmail());
+        AuthPasswordDto authPasswordDto = new AuthPasswordDto();
+        authPasswordDto.setEmail("s20018@gsm.hs.kr");
+        authPasswordDto.setAnswer("노갱");
 
         // when
         memberService.signup(memberDto);
-        Member result = emailService.authPassword(emailDto);
+        Member result = emailService.authPassword(authPasswordDto);
 
         // then
         assertThat(result.getPassword()).isEqualTo(memberRepository.findByEmail(memberDto.getEmail()).getPassword());


### PR DESCRIPTION
### 제가 한일은요!
- AuthPassword ( 이메일로 임시 비밀번호를 발급해주는 기능 ) 로직의 문제가 있어서 수정 했습니다.
- AuthPassword 의 answer( 질문 답 ) 을 검증할 수 있는 로직 추가
- 변수명 통일 ( ex. UserEmail -> email )
- User, RefreshToken, Email 의 Controller, ServiceImpl 주석 추가

> 다음 PR은 안쓰이는 import 삭제할 예정입니다~
