### PR TITLE
질문 대답, 토큰 리프레시 Exception 처리 + Member username 컬럼 unique 속성 추가

### DIFF
--- a/src/main/java/com/server/Dotori/model/member/Member.java
+++ b/src/main/java/com/server/Dotori/model/member/Member.java
@@ -33,7 +33,7 @@ public class Member implements UserDetails {
     @Column(name = "member_id")
     private Long id;
 
-    @Column(name = "member_username", nullable = false)
+    @Column(name = "member_username", nullable = false, unique = true)
     private String username;
 
     @Column(name = "member_stdnum", nullable = false, unique = true)

--- a/src/main/java/com/server/Dotori/model/member/service/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/RefreshTokenServiceImpl.java
@@ -1,6 +1,7 @@
 package com.server.Dotori.model.member.service;
 
 import com.server.Dotori.exception.token.exception.LogoutTokenException;
+import com.server.Dotori.exception.token.exception.RefreshTokenFailException;
 import com.server.Dotori.exception.user.exception.UserNotFoundException;
 import com.server.Dotori.model.member.Member;
 import com.server.Dotori.model.member.dto.MemberDto;
@@ -59,6 +60,6 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
             return map;
         }
 
-        throw new IllegalArgumentException("토큰 재발급에 실패했습니다.");
+        throw new RefreshTokenFailException();
     }
 }

--- a/src/main/java/com/server/Dotori/model/member/service/email/EmailServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/email/EmailServiceImpl.java
@@ -1,5 +1,6 @@
 package com.server.Dotori.model.member.service.email;
 
+import com.server.Dotori.exception.user.exception.UserAuthenticationAnswerNotMatchingException;
 import com.server.Dotori.exception.user.exception.UserNotFoundException;
 import com.server.Dotori.model.member.Member;
 import com.server.Dotori.model.member.dto.AuthPasswordDto;
@@ -67,7 +68,7 @@ public class EmailServiceImpl implements EmailService {
         String email = authPasswordDto.getEmail();
         Member findMember = memberRepository.findByEmail(authPasswordDto.getEmail());
         if(findMember == null) throw new UserNotFoundException();
-        if(!findMember.getAnswer().equals(authPasswordDto.getAnswer())) throw new IllegalArgumentException("질문 답이 일치하지 않습니다.");
+        if(!findMember.getAnswer().equals(authPasswordDto.getAnswer())) throw new UserAuthenticationAnswerNotMatchingException();
 
         String password = getTempPassword();
         emailSendService.sendPasswordEmail(email,password);


### PR DESCRIPTION
### 제가 한일은요!
- 질문 대답, 토큰 리프레시의 Exception 메시지를 수정했습니다.
- Member username 컬럼에 unique 속성을 추가했습니다.

> username 컬럼에 unique 속성을 추가한 이유는 중복된 이름을 가입시키기 위함입니다. 현재 서비스 로직상 이름이 중복되버리면 꼬여버리는 상황이 발생하는데 이를 방지하기 위함입니다. 다음에는 코드리펙토링을하여 username에 unique속성대신에 다른 방법을 찾아보도록 하겠습니다.