### PR TITLE
board, music Exception

### DIFF
--- a/src/main/java/com/server/Dotori/model/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/board/service/BoardServiceImpl.java
@@ -1,6 +1,7 @@
 package com.server.Dotori.model.board.service;
 
 import com.querydsl.core.Tuple;
+import com.server.Dotori.exception.board.exception.BoardEmptyException;
 import com.server.Dotori.exception.board.exception.BoardNotFoundException;
 import com.server.Dotori.model.board.Board;
 import com.server.Dotori.model.board.dto.BoardGetDto;
@@ -45,6 +46,8 @@ public class BoardServiceImpl implements BoardService {
     @Override
     public Page<BoardGetDto> getAllBoard(Pageable pageable) {
         Page<Board> boardPage = boardRepository.findAll(pageable);
+
+        if (boardPage.isEmpty()) throw new BoardEmptyException();
 
         return boardPage.map(board -> {
             ModelMapper mapper = new ModelMapper();

--- a/src/main/java/com/server/Dotori/model/music/service/MusicServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/music/service/MusicServiceImpl.java
@@ -1,5 +1,8 @@
 package com.server.Dotori.model.music.service;
 
+import com.server.Dotori.exception.music.exception.MusicAlreadyException;
+import com.server.Dotori.exception.music.exception.MusicNotAppliedException;
+import com.server.Dotori.exception.music.exception.MusicNotFoundException;
 import com.server.Dotori.model.member.Member;
 import com.server.Dotori.model.music.Music;
 import com.server.Dotori.model.music.dto.MusicApplicationDto;
@@ -40,7 +43,7 @@ public class MusicServiceImpl implements MusicService {
             return music;
 
         } else {
-            throw new IllegalArgumentException("이미 음악을 신청하신 회원입니다"); //Exception생성하여 예외처리하기
+            throw new MusicAlreadyException();
         }
     }
 
@@ -54,8 +57,8 @@ public class MusicServiceImpl implements MusicService {
     public List<MusicResDto> getAllMusic() {
         List<MusicResDto> allMusic = musicRepository.findAllMusic();
 
-        if (allMusic.isEmpty()) throw new IllegalArgumentException("신청된 음악이 없습니다.");
-        return allMusic;
+        if (allMusic.isEmpty()) throw new MusicNotAppliedException();
+        else return allMusic;
     }
 
     /**
@@ -67,7 +70,7 @@ public class MusicServiceImpl implements MusicService {
     @Override
     public void deleteMusic(Long musicId) {
         Music music = musicRepository.findById(musicId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 신청된 음악을 찾을 수 없습니다."));
+                .orElseThrow(() -> new MusicNotFoundException());
 
         musicRepository.deleteById(music.getId());
     }


### PR DESCRIPTION
### 제가 한 일이에요
* board service 추가된 Exception으로 변경
* music service 추가된 Exception으로 변경

> Music에서 **음악 삭제에 성공**했을 때 
또는 
**음악목록을 조회했지만 신청된 음악이 없을 경우** 
**ResponseBody가 아래 사진과 같이 나오지 않습니다.** 

>이유는 **Exception message HTTP Status**가 `204`, 즉 `NO_CONTENT` 
또는 `404`, `NOT_FOUND`라서 
**ResponseBody가 리턴되지 않습니다.**.
이유 찾느라 3시간정도 쓴 것 같네요 ㅠㅠ 

![스크린샷 2021-09-19 오후 6 02 48](https://user-images.githubusercontent.com/69895394/133921754-7759fc1c-ab33-4b4a-b145-19c8f02af8fc.png)

![스크린샷 2021-09-19 오후 6 03 00](https://user-images.githubusercontent.com/69895394/133921750-be83efff-271e-43b0-8ca5-78b7a1947a0a.png)

### HTTP Status를 200, OK로 했을 때
![스크린샷 2021-09-19 오후 6 09 56](https://user-images.githubusercontent.com/69895394/133921875-9c3d8a9f-92f3-45e3-9879-52c2a6fe8985.png)

![스크린샷 2021-09-19 오후 6 10 01](https://user-images.githubusercontent.com/69895394/133921873-037e32c0-e513-46b1-9414-ad01e9c707cd.png)

#### @TeMlN 님은 오늘 저와 함께 Exception message를 모두 점검하며 고치도록 합시다..

