### PR TITLE
SecurityConfig 권한별 Url 접속 에러 수정

### DIFF
--- a/src/main/java/com/server/Dotori/security/SecurityConfig.java
+++ b/src/main/java/com/server/Dotori/security/SecurityConfig.java
@@ -51,23 +51,24 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http.authorizeRequests() // 권한 처리를 할 메서드
 
                 // 회원 관리
-                .antMatchers("/v1/signin").permitAll()
-                .antMatchers("/v1/signup").permitAll()
-                .antMatchers("/v1/refreshtoken").permitAll()
-                .antMatchers("/v1/auth").permitAll()
-                .antMatchers("/v1/auth/check").permitAll()
-                .antMatchers("/v1/change/password").permitAll()
-                .antMatchers("/v1/auth/password").permitAll()
-                .antMatchers("/v1/member/logout").permitAll()
-                .antMatchers("/v1/member/delete").permitAll()
+//                .antMatchers("/v1/signin").permitAll()
+//                .antMatchers("/v1/signup").permitAll()
+//                .antMatchers("/v1/refreshtoken").permitAll()
+//                .antMatchers("/v1/auth").permitAll()
+//                .antMatchers("/v1/auth/check").permitAll()
+//                .antMatchers("/v1/change/password").permitAll()
+//                .antMatchers("/v1/auth/password").permitAll()
+//                .antMatchers("/v1/member/logout").authenticated()
+//                .antMatchers("/v1/member/delete").authenticated()
 
                 // 권한 별 url 접근
-                .antMatchers("/v1/admin/**").hasRole("ADMIN")
-                .antMatchers("/v1/councillor/**").hasRole("COUNCILLOR")
-                .antMatchers("/v1/member/**").hasRole("MEMBER")
-                .antMatchers("/v1/developer/**").hasRole("DEVELOPER")
+//                .antMatchers("/v1/admin/**").hasRole("ADMIN")
+//                .antMatchers("/v1/councillor/**").hasRole("COUNCILLOR")
+//                .antMatchers("/v1/member/**").hasRole("MEMBER")
+//                .antMatchers("/v1/developer/**").hasRole("DEVELOPER")
 
                 // exception 메세지, h2-console 모두 접근 가능
+                .antMatchers("/**").permitAll()
                 .antMatchers("/").permitAll()
                 .antMatchers("/exception/**").permitAll()
                 .antMatchers("/h2-console").permitAll()

--- a/src/main/java/com/server/Dotori/security/SecurityConfig.java
+++ b/src/main/java/com/server/Dotori/security/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.server.Dotori.security;
 
+import com.server.Dotori.security.jwt.JwtTokenFilter;
+import com.server.Dotori.security.jwt.JwtTokenFilterConfigurer;
+import com.server.Dotori.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,12 +14,16 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @EnableWebSecurity(debug = true)
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
-    @Override
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override // 접근 가능
     public void configure(WebSecurity web) throws Exception {
 
         web.ignoring().antMatchers("/v2/api-docs")//
@@ -41,18 +48,36 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
         // Entry points
-        http.authorizeRequests()
+        http.authorizeRequests() // 권한 처리를 할 메서드
+
+                // 회원 관리
+                .antMatchers("/v1/signin").permitAll()
+                .antMatchers("/v1/signup").permitAll()
+                .antMatchers("/v1/refreshtoken").permitAll()
+                .antMatchers("/v1/auth").permitAll()
+                .antMatchers("/v1/auth/check").permitAll()
+                .antMatchers("/v1/change/password").permitAll()
+                .antMatchers("/v1/auth/password").permitAll()
+                .antMatchers("/v1/member/logout").permitAll()
+                .antMatchers("/v1/member/delete").permitAll()
+
+                // 권한 별 url 접근
+                .antMatchers("/v1/admin/**").hasRole("ADMIN")
+                .antMatchers("/v1/councillor/**").hasRole("COUNCILLOR")
+                .antMatchers("/v1/member/**").hasRole("MEMBER")
+                .antMatchers("/v1/developer/**").hasRole("DEVELOPER")
+
+                // exception 메세지, h2-console 모두 접근 가능
                 .antMatchers("/").permitAll()
-                .antMatchers("/v1/admin/test").hasRole("ADMIN")
-                .antMatchers("/v1/member/test").hasRole("MEMBER")
-                .antMatchers("/v1/councillor/test").hasRole("COUNCILLOR")
-                .antMatchers("/v1/developer/test").hasRole("DEVELOPER")
                 .antMatchers("/exception/**").permitAll()
                 .antMatchers("/h2-console").permitAll()
                 .antMatchers("/h2-console/**/**").permitAll()
-                .antMatchers("/**").permitAll()
+
                 // Disallow everything else..
-                .anyRequest().authenticated();
+                .anyRequest().authenticated()
+                .and()
+                .addFilterBefore(new JwtTokenFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class); // 모든 기능이 동작하기전 권한을 체크해줌
+
 
         // If a user try to access a resource without having enough permissions
         http.exceptionHandling().accessDeniedPage("/login");


### PR DESCRIPTION
### 제가 한일은요!
- 일치하는 권한으로 url을 접속했을때 안되던 에러를 수정했습니다.

> 현재 더 확인해야할게 있지만 Exception메세지가 불특정하게 나오고 -9999 에러, 에러가 일치하지 않으므로 작업하기가 힘듭니다. 우선 @TeMlN 님의 에러가 빨리 고쳐져야지 제 기능도 완벽히 완성할 수 있을것같습니다.

![2021-09-20_17-47-54](https://user-images.githubusercontent.com/68670670/133977081-96e3af77-a53d-4c25-ad8c-670ca30b3d54.png)
> 위 이미지는 ```ADMIN``` , ```COUNCILLOR```, ```MEMBER```, ```DEVELOPER``` 권한 모두 가입시킨 이미지입니다.

<img width="1413" alt="2021-09-20_17-51-24" src="https://user-images.githubusercontent.com/68670670/133977288-7bc3da39-9765-4afa-a434-18beb86f8ad1.png">

> ```/v1/admin/board``` 를 ```ADMIN``` 으로 접근했을때 뜨는 메세지 (정상적으로 잘뜹니다.)

<img width="1416" alt="2021-09-20_17-54-31" src="https://user-images.githubusercontent.com/68670670/133977669-e0856129-c45c-415e-8eef-b1a588928b64.png">

> ```/v1/admin/board```를 ```COUNCILLOR``` 으로 접근했을때 뜨는 메세지 (이 에러메세지가 현재 권한이 맞지 않다고 떠야합니다.)


