### PR TITLE
xss response filter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,10 @@ dependencies {
 
 	// *** QueryDsl *** //
 	implementation 'com.querydsl:querydsl-jpa'
+
+	//*** XSS 처리를 위한 dependency ***//
+	implementation 'org.apache.commons:commons-lang3'
+	implementation 'org.apache.commons:commons-text:1.9'
 }
 
 test {

--- a/src/main/java/com/server/Dotori/config/web/WebConfig.java
+++ b/src/main/java/com/server/Dotori/config/web/WebConfig.java
@@ -1,9 +1,21 @@
 package com.server.Dotori.config.web;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.server.Dotori.config.xss.HTMLCharacterEscapes;
 import io.swagger.models.HttpMethod;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+import static com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
@@ -19,5 +31,28 @@ public class WebConfig implements WebMvcConfigurer {
                         HttpMethod.DELETE.name()
                 )
                 .maxAge(3600);
+    }
+
+    @Override
+    public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+        converters.add(htmlEscapingConverter());
+    }
+
+    /**
+     *  MappingJackson2HttpMessageConverter 를 커스터마이징 하여
+     *  응답 객체 이스케이프 문자 설정
+     * @return 커스텀 설정이 적용된 컨버터
+     * @author 배태현
+     */
+    @Bean
+    public HttpMessageConverter htmlEscapingConverter() {
+        ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        objectMapper.configure(ALLOW_UNQUOTED_CONTROL_CHARS, true);
+        objectMapper.getFactory().setCharacterEscapes(new HTMLCharacterEscapes()); //  xss 처리 문자 세팅
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        MappingJackson2HttpMessageConverter htmlEscapingConverter = new MappingJackson2HttpMessageConverter();
+        htmlEscapingConverter.setObjectMapper(objectMapper);
+        return htmlEscapingConverter;
     }
 }

--- a/src/main/java/com/server/Dotori/config/xss/HTMLCharacterEscapes.java
+++ b/src/main/java/com/server/Dotori/config/xss/HTMLCharacterEscapes.java
@@ -1,0 +1,2 @@
+package com.server.Dotori.config.xss;public class HTMLCharacterEscapes {
+}

--- a/src/main/java/com/server/Dotori/config/xss/HTMLCharacterEscapes.java
+++ b/src/main/java/com/server/Dotori/config/xss/HTMLCharacterEscapes.java
@@ -1,2 +1,56 @@
-package com.server.Dotori.config.xss;public class HTMLCharacterEscapes {
+package com.server.Dotori.config.xss;
+
+import com.fasterxml.jackson.core.SerializableString;
+import com.fasterxml.jackson.core.io.CharacterEscapes;
+import com.fasterxml.jackson.core.io.SerializedString;
+import org.apache.commons.text.translate.AggregateTranslator;
+import org.apache.commons.text.translate.CharSequenceTranslator;
+import org.apache.commons.text.translate.EntityArrays;
+import org.apache.commons.text.translate.LookupTranslator;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class HTMLCharacterEscapes extends CharacterEscapes {
+
+    private final int[] asciiEscapes;
+
+    private final CharSequenceTranslator translator;
+
+    public HTMLCharacterEscapes() {
+        Map<CharSequence, CharSequence> customMap = new HashMap<CharSequence, CharSequence>();
+        customMap.put("<", "&#60;");
+        customMap.put(">", "&#62;");
+        customMap.put("$", "&#36;");
+        customMap.put(";", "&#59;");
+        customMap.put("`", "&#96;");
+        Map<CharSequence, CharSequence> CUSTOM_ESCAPE = Collections.unmodifiableMap(customMap);
+
+        // 1. XSS 방지 처리할 특수 문자 지정
+        asciiEscapes = CharacterEscapes.standardAsciiEscapesForJSON();
+        asciiEscapes['<'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['>'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['$'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes[';'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['`'] = CharacterEscapes.ESCAPE_CUSTOM;
+
+        // 2. XSS 방지 처리 특수 문자 인코딩 값 지정
+        translator = new AggregateTranslator(
+                new LookupTranslator(EntityArrays.BASIC_ESCAPE),  // <, >, &, " 는 여기에 포함됨
+                new LookupTranslator(EntityArrays.ISO8859_1_ESCAPE),
+                new LookupTranslator(EntityArrays.HTML40_EXTENDED_ESCAPE),
+                new LookupTranslator(CUSTOM_ESCAPE)
+        );
+    }
+
+    @Override
+    public int[] getEscapeCodesForAscii() {
+        return asciiEscapes;
+    }
+
+    @Override
+    public SerializableString getEscapeSequence(int ch) {
+        return new SerializedString(translator.translate(Character.toString((char) ch)));
+    }
 }


### PR DESCRIPTION
### 제가 한 일이에요 !
* 의존성 추가
* xss response filter처리

> Spring 버전이 업데이트 되면서 `HttpsServletRequest` 부모 클래스의 구현 법이 조금 달라졌다고 합니다.
그리하여 response때에만 처리를 할 수 있다고 합니다. (xss공격 특성상 response에서만 처리되어도 상관없음)

### 예시 사진
* **입력값**
![스크린샷 2021-10-01 오후 12 13 04](https://user-images.githubusercontent.com/69895394/135560486-f6a3bed7-ee84-48d9-807d-79ae4bdf25ab.png)

---

* **결과값 (response값)**
![스크린샷 2021-10-01 오후 12 13 13](https://user-images.githubusercontent.com/69895394/135560455-7875382c-e8de-474a-9b65-d2d2e65b8158.png)
)

---

* **DB에 저장된 값 (위에 말했던 것 처럼 response때에만 처리가 가능하기 때문에 DB에는 입력받은 값 그대로 저장됩니다)**
![스크린샷 2021-10-01 오후 12 18 18](https://user-images.githubusercontent.com/69895394/135560452-75616667-0371-49af-a1e7-320715d3f25d.png)
