### PR TITLE
음악, 자습신청/취소 가능 시간 지정과 검증

### DIFF
--- a/src/main/java/com/server/Dotori/model/member/controller/selfstudy/councillor/CouncillorSelfStudyController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/selfstudy/councillor/CouncillorSelfStudyController.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
+
 @RestController
 @RequestMapping("/v1/councillor")
 @RequiredArgsConstructor
@@ -32,7 +34,8 @@ public class CouncillorSelfStudyController {
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
     public CommonResult requestSelfStudyCouncillor() {
-        selfStudyService.requestSelfStudy();
+        LocalDateTime currentTime = LocalDateTime.now();
+        selfStudyService.requestSelfStudy(currentTime.getDayOfWeek(), currentTime.getHour());
         return responseService.getSuccessResult();
     }
 
@@ -49,7 +52,8 @@ public class CouncillorSelfStudyController {
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
     public CommonResult cancelSelfStudyCouncillor() {
-        selfStudyService.cancelSelfStudy();
+        LocalDateTime currentTime = LocalDateTime.now();
+        selfStudyService.cancelSelfStudy(currentTime.getDayOfWeek(), currentTime.getHour());
         return responseService.getSuccessResult();
     }
 

--- a/src/main/java/com/server/Dotori/model/member/controller/selfstudy/developer/DeveloperSelfStudyController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/selfstudy/developer/DeveloperSelfStudyController.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
+
 @RestController
 @RequestMapping("/v1/developer")
 @RequiredArgsConstructor
@@ -32,7 +34,8 @@ public class DeveloperSelfStudyController {
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
     public CommonResult requestSelfStudyDeveloper() {
-        selfStudyService.requestSelfStudy();
+        LocalDateTime currentTime = LocalDateTime.now();
+        selfStudyService.requestSelfStudy(currentTime.getDayOfWeek(), currentTime.getHour());
         return responseService.getSuccessResult();
     }
 
@@ -49,7 +52,8 @@ public class DeveloperSelfStudyController {
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
     public CommonResult cancelSelfStudyDeveloper() {
-        selfStudyService.cancelSelfStudy();
+        LocalDateTime currentTime = LocalDateTime.now();
+        selfStudyService.cancelSelfStudy(currentTime.getDayOfWeek(), currentTime.getHour());
         return responseService.getSuccessResult();
     }
 

--- a/src/main/java/com/server/Dotori/model/member/controller/selfstudy/member/MemberSelfStudyController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/selfstudy/member/MemberSelfStudyController.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
+
 @RestController
 @RequestMapping("/v1/member")
 @RequiredArgsConstructor
@@ -32,7 +34,8 @@ public class MemberSelfStudyController {
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
     public CommonResult requestSelfStudy() {
-        selfStudyService.requestSelfStudy();
+        LocalDateTime currentTime = LocalDateTime.now();
+        selfStudyService.requestSelfStudy(currentTime.getDayOfWeek(), currentTime.getHour());
         return responseService.getSuccessResult();
     }
 
@@ -49,7 +52,8 @@ public class MemberSelfStudyController {
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
     public CommonResult cancelSelfStudyMember() {
-        selfStudyService.cancelSelfStudy();
+        LocalDateTime currentTime = LocalDateTime.now();
+        selfStudyService.cancelSelfStudy(currentTime.getDayOfWeek(), currentTime.getHour());
         return responseService.getSuccessResult();
     }
 

--- a/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyService.java
+++ b/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyService.java
@@ -2,13 +2,14 @@ package com.server.Dotori.model.member.service.selfstudy;
 
 import com.server.Dotori.model.member.dto.SelfStudyStudentsDto;
 
+import java.time.DayOfWeek;
 import java.util.List;
 
 public interface SelfStudyService {
 
-    void requestSelfStudy();
+    void requestSelfStudy(DayOfWeek dayOfWeek, int hour);
 
-    void cancelSelfStudy();
+    void cancelSelfStudy(DayOfWeek dayOfWeek, int hour);
 
     List<SelfStudyStudentsDto> getSelfStudyStudents();
 

--- a/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.DayOfWeek;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.server.Dotori.model.member.enumType.SelfStudy.*;
@@ -36,6 +35,8 @@ public class SelfStudyServiceImpl implements SelfStudyService {
      * 금요일, 토요일, 일요일에는 자습신청 불가능 <br>
      * 위 요일을 제외한 나머지 요일에는 오후 8시부터 오후 10시까지만 자습신청 가능 <br>
      * 자습신청 할 시 '신청함'으로 상태변경 <br>
+     * @param dayOfWeek 현재 요일
+     * @param hour 현재 시
      * @exception SelfStudyCantApplied 자습신청 상태가 CAN(가능)이 아닐 때 (자습신청을 할 수 없는 상태)
      * @exception SelfStudyOverPersonal 자습신청 인원이 50명이 넘었을 때
      * @exception
@@ -44,12 +45,9 @@ public class SelfStudyServiceImpl implements SelfStudyService {
      */
     @Override
     @Transactional
-    public void requestSelfStudy() {
-        DayOfWeek dayOfWeek = LocalDateTime.now().getDayOfWeek();
-        int hour = LocalDateTime.now().getHour();
-
+    public void requestSelfStudy(DayOfWeek dayOfWeek, int hour) {
         if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new IllegalArgumentException("자습신청이 가능한 요일이 아닙니다.");
-        if (!(hour >= 20 && hour < 23)) throw new IllegalArgumentException("8시부터 10시까지만 자습신청이 가능합니다."); // 20시(8시)부터 22시(10시) 사이가 아니라면 자습신청 불가능
+        if (!(hour >= 20 && hour < 23)) throw new IllegalArgumentException("오후 8시부터 오후 10시까지만 자습신청이 가능합니다."); // 20시(8시)부터 22시(10시) 사이가 아니라면 자습신청 불가능
 
         Member currentUser = currentUserUtil.getCurrentUser();
 
@@ -66,13 +64,20 @@ public class SelfStudyServiceImpl implements SelfStudyService {
 
     /**
      * 자습신청 서비스 로직 (로그인 된 유저 사용가능) <br>
+     * 금요일, 토요일, 일요일에는 자습신청 취소 불가능 <br>
+     * 위 요일을 제외한 나머지 요일에는 오후 8시부터 오후 10시까지만 자습신청 취소 가능 <br>
      * 자습신청을 취소할 시 그 날 자습신청 불가능
+     * @param dayOfWeek 현재 요일
+     * @param hour 현재 시
      * @exception SelfStudyCantChange 자습신청 상태가 APPLIED(신청됨)가 아닐 때 (자습신청 취소를 할 수 없는 상태)
      * @author 배태현
      */
     @Override
     @Transactional
-    public void cancelSelfStudy() {
+    public void cancelSelfStudy(DayOfWeek dayOfWeek, int hour) {
+        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new IllegalArgumentException("자습신청 취소가 가능한 요일이 아닙니다.");
+        if (!(hour >= 20 && hour < 23)) throw new IllegalArgumentException("오후 8시부터 오후 10시까지만 자습신청 취소가 가능합니다."); // 20시(8시)부터 22시(10시) 사이가 아니라면 자습신청 취소 불가능
+
         Member currentUser = currentUserUtil.getCurrentUser();
 
         if (currentUser.getSelfStudy() == APPLIED) {

--- a/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
@@ -14,6 +14,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.server.Dotori.model.member.enumType.SelfStudy.*;
@@ -31,14 +33,24 @@ public class SelfStudyServiceImpl implements SelfStudyService {
     /**
      * 자습 신청 서비스로직 (로그인 된 유저 사용가능) <br>
      * 50명까지 신청 가능, 자습신청 상태가 '가능'인 사람만 신청가능 <br>
-     * 자습신청 할 시 '신청함'으로 상태변경
+     * 금요일, 토요일, 일요일에는 자습신청 불가능 <br>
+     * 위 요일을 제외한 나머지 요일에는 오후 8시부터 오후 10시까지만 자습신청 가능 <br>
+     * 자습신청 할 시 '신청함'으로 상태변경 <br>
      * @exception SelfStudyCantApplied 자습신청 상태가 CAN(가능)이 아닐 때 (자습신청을 할 수 없는 상태)
      * @exception SelfStudyOverPersonal 자습신청 인원이 50명이 넘었을 때
+     * @exception
+     * @exception
      * @author 배태현
      */
     @Override
     @Transactional
     public void requestSelfStudy() {
+        DayOfWeek dayOfWeek = LocalDateTime.now().getDayOfWeek();
+        int hour = LocalDateTime.now().getHour();
+
+        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new IllegalArgumentException("자습신청이 가능한 요일이 아닙니다.");
+        if (!(hour >= 20 && hour < 23)) throw new IllegalArgumentException("8시부터 10시까지만 자습신청이 가능합니다."); // 20시(8시)부터 22시(10시) 사이가 아니라면 자습신청 불가능
+
         Member currentUser = currentUserUtil.getCurrentUser();
 
         if (count <= 50){

--- a/src/main/java/com/server/Dotori/model/music/controller/councillor/CouncillorMusicController.java
+++ b/src/main/java/com/server/Dotori/model/music/controller/councillor/CouncillorMusicController.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -37,7 +38,7 @@ public class CouncillorMusicController {
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
     public CommonResult musicCouncillor(@Valid @RequestBody MusicApplicationDto musicApplicationDto) {
-        musicService.musicApplication(musicApplicationDto);
+        musicService.musicApplication(musicApplicationDto, LocalDateTime.now().getDayOfWeek());
         return responseService.getSuccessResult();
     }
 

--- a/src/main/java/com/server/Dotori/model/music/controller/developer/DeveloperMusicController.java
+++ b/src/main/java/com/server/Dotori/model/music/controller/developer/DeveloperMusicController.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -37,7 +38,7 @@ public class DeveloperMusicController {
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
     public CommonResult musicDeveloper(@Valid @RequestBody MusicApplicationDto musicApplicationDto) {
-        musicService.musicApplication(musicApplicationDto);
+        musicService.musicApplication(musicApplicationDto, LocalDateTime.now().getDayOfWeek());
         return responseService.getSuccessResult();
     }
 

--- a/src/main/java/com/server/Dotori/model/music/controller/member/MemberMusicController.java
+++ b/src/main/java/com/server/Dotori/model/music/controller/member/MemberMusicController.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -37,7 +38,7 @@ public class MemberMusicController {
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
     public CommonResult musicMember(@Valid @RequestBody MusicApplicationDto musicApplicationDto) {
-        musicService.musicApplication(musicApplicationDto);
+        musicService.musicApplication(musicApplicationDto, LocalDateTime.now().getDayOfWeek());
         return responseService.getSuccessResult();
     }
 

--- a/src/main/java/com/server/Dotori/model/music/service/MusicService.java
+++ b/src/main/java/com/server/Dotori/model/music/service/MusicService.java
@@ -4,11 +4,13 @@ import com.server.Dotori.model.music.Music;
 import com.server.Dotori.model.music.dto.MusicApplicationDto;
 import com.server.Dotori.model.music.dto.MusicResDto;
 
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface MusicService {
 
-    Music musicApplication(MusicApplicationDto musicApplicationDto);
+    Music musicApplication(MusicApplicationDto musicApplicationDto, DayOfWeek dayofWeek);
 
     List<MusicResDto> getAllMusic();
 

--- a/src/main/java/com/server/Dotori/model/music/service/MusicServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/music/service/MusicServiceImpl.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.DayOfWeek;
 import java.util.List;
 
 import static com.server.Dotori.model.member.enumType.Music.*;
@@ -26,16 +27,19 @@ public class MusicServiceImpl implements MusicService {
 
     /**
      * 음악을 신청하는 서비스 로직 (로그인된 유저 사용가능) <br>
-     * 이미 음악을 신청한 학생이라면?
-     * @exception
+     * 금요일, 토요일에는 음악신청 불가능
      * @param musicApplicationDto musicApplicationDto (musicUrl)
+     * @param dayOfWeek 현재 요일
      * @exception MusicAlreadyException 음악신청 상태가 CAN이 아닐 때
+     * @exception
      * @return Music
      * @author 배태현
      */
     @Override
     @Transactional
-    public Music musicApplication(MusicApplicationDto musicApplicationDto) {
+    public Music musicApplication(MusicApplicationDto musicApplicationDto, DayOfWeek dayOfWeek) {
+        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY) throw new IllegalArgumentException("음악신청을 하실 수 없는 요일입니다.");
+
         Member currentUser = currentUserUtil.getCurrentUser();
 
         if (currentUser.getMusic() == CAN) {

--- a/src/test/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceTest.java
@@ -19,6 +19,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
+import java.time.DayOfWeek;
 import java.util.Collections;
 import java.util.List;
 
@@ -72,7 +73,7 @@ class SelfStudyServiceTest {
     @Test
     @DisplayName("자습신청이 제대로 되나요?")
     public void requestSelfStudyTest() {
-        selfStudyService.requestSelfStudy();
+        selfStudyService.requestSelfStudy(DayOfWeek.MONDAY, 21); // 월요일 9시
 
         assertEquals(SelfStudy.APPLIED, currentUserUtil.getCurrentUser().getSelfStudy());
     }
@@ -80,8 +81,8 @@ class SelfStudyServiceTest {
     @Test
     @DisplayName("자습신청 취소가 제대로 되나요?")
     public void cancelSelfStudy() {
-        selfStudyService.requestSelfStudy();
-        selfStudyService.cancelSelfStudy();
+        selfStudyService.requestSelfStudy(DayOfWeek.MONDAY, 21);
+        selfStudyService.cancelSelfStudy(DayOfWeek.MONDAY, 21);
 
         assertEquals(CANT, currentUserUtil.getCurrentUser().getSelfStudy());
     }
@@ -90,7 +91,7 @@ class SelfStudyServiceTest {
     @DisplayName("자습 신청한 학생들 목록이 잘 조회 되나요?")
     public void getSelfStudyStudents() {
         //given //when
-        selfStudyService.requestSelfStudy();
+        selfStudyService.requestSelfStudy(DayOfWeek.MONDAY, 21);
         List<SelfStudyStudentsDto> selfStudyStudents = selfStudyService.getSelfStudyStudents();
 
         //then
@@ -101,7 +102,7 @@ class SelfStudyServiceTest {
     @DisplayName("자습신청한 학생들의 목록이 학년반별 카테고리 목록으로 조회 되나요?")
     public void getSelfStudyStudentsCategoryTest() {
         //given //when
-        selfStudyService.requestSelfStudy();
+        selfStudyService.requestSelfStudy(DayOfWeek.MONDAY, 21);
         List<SelfStudyStudentsDto> selfStudyStudentsByCategory = selfStudyService.getSelfStudyStudentsByCategory(24L);
 
         //then
@@ -171,7 +172,7 @@ class SelfStudyServiceTest {
     @DisplayName("자습신청한 학생 수 카운트가 잘 세지나요?")
     public void selfStudyCountTest() {
         //given //when
-        selfStudyService.requestSelfStudy();
+        selfStudyService.requestSelfStudy(DayOfWeek.MONDAY, 21);
 
         Integer selfStudyCount = selfStudyService.selfStudyCount();
 

--- a/src/test/java/com/server/Dotori/model/music/service/MusicServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/music/service/MusicServiceTest.java
@@ -1,6 +1,5 @@
 package com.server.Dotori.model.music.service;
 
-import com.server.Dotori.model.board.Board;
 import com.server.Dotori.model.member.Member;
 import com.server.Dotori.model.member.dto.MemberDto;
 import com.server.Dotori.model.member.enumType.Role;
@@ -12,7 +11,6 @@ import com.server.Dotori.model.music.dto.MusicApplicationDto;
 import com.server.Dotori.model.music.dto.MusicResDto;
 import com.server.Dotori.model.music.repository.MusicRepository;
 import com.server.Dotori.util.CurrentUserUtil;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,10 +19,10 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.annotation.Commit;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
+import java.time.DayOfWeek;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -36,7 +34,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
-//@Commit
 class MusicServiceTest {
 
     @Autowired private MusicService musicService;
@@ -85,7 +82,8 @@ class MusicServiceTest {
         Music music = musicService.musicApplication(
                 MusicApplicationDto.builder()
                         .musicUrl("https://www.youtube.com/watch?v=6h9qmKWK6Io")
-                        .build()
+                        .build(),
+                DayOfWeek.MONDAY // 월요일
         );
 
         //then


### PR DESCRIPTION
### 제가 한 일이에요 !
* 음악신청 가능시간 지정 (금요일, 토요일 신청 불가능)
* 자습신청 가능 시간 지정 (금요일, 토요일, 일요일 신청 불가능, 오후 8시부터 10시까지만 자습신청 가능)
* 자습신청 취소 시간 지정 (금요일, 토요일, 일요일 신청 취소 불가능, 오후 8시부터 10시까지만 자습신청 취소 가능)
* 서비스 로직이 실행 가능한 시간이 추가되며 양치기 테스트가 될 가능성이 있어 방지하기 위해 
서비스로직의 변경과 테스트코드의 변경이 일어났습니다.
> 양치기 테스트 방지를 위한 테스트코드에서 특정 시간 고정 
(테스트는 언제 돌리던 같은 결과가 나와야한다. (아닐 시 양치기 테스트라고 한다))

### 현 PR이 merge되면 @TeMlN 님이 Exception을 추가해주시길 바랍니다.

**음악신청**
* 음악신청을 하실 수 없는 요일입니다 exception

**자습신청**
* 자습신청을 하실 수 없는 요일입니다 exception
* 자습신청은 오후 8시부터 오후 10시까지만  가능합니다 exception

**자습신청 취소**
* 자습신청을 취소 하실 수 없는 요일입니다 exception
* 자습신청은 오후 8시부터 오후 10시까지만 취소가 가능합니다 exception

> 이와같이 메세지 지정해주시고 **Exception 작명이 애매할 시 꼭 Slack에 올려 의견을 모아 작명해주시길 바랍니다.**