### PR TITLE
자습신청/취소, 기상음악 신청 시간, 날짜에 따른 예외

### DIFF
--- a/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
@@ -1,9 +1,9 @@
 package com.server.Dotori.model.member.service.selfstudy;
 
-import com.server.Dotori.exception.selfstudy.exception.SelfStudyCantApplied;
-import com.server.Dotori.exception.selfstudy.exception.SelfStudyCantChange;
-import com.server.Dotori.exception.selfstudy.exception.SelfStudyNotFound;
-import com.server.Dotori.exception.selfstudy.exception.SelfStudyOverPersonal;
+import com.server.Dotori.exception.selfstudy.exception.SelfStudyCantAppliedException;
+import com.server.Dotori.exception.selfstudy.exception.SelfStudyCantChangeException;
+import com.server.Dotori.exception.selfstudy.exception.SelfStudyNotFoundException;
+import com.server.Dotori.exception.selfstudy.exception.SelfStudyOverPersonalException;
 import com.server.Dotori.exception.user.exception.UserNotFoundByClassException;
 import com.server.Dotori.model.member.Member;
 import com.server.Dotori.model.member.dto.SelfStudyStudentsDto;
@@ -37,8 +37,8 @@ public class SelfStudyServiceImpl implements SelfStudyService {
      * 자습신청 할 시 '신청함'으로 상태변경 <br>
      * @param dayOfWeek 현재 요일
      * @param hour 현재 시
-     * @exception SelfStudyCantApplied 자습신청 상태가 CAN(가능)이 아닐 때 (자습신청을 할 수 없는 상태)
-     * @exception SelfStudyOverPersonal 자습신청 인원이 50명이 넘었을 때
+     * @exception SelfStudyCantAppliedException 자습신청 상태가 CAN(가능)이 아닐 때 (자습신청을 할 수 없는 상태)
+     * @exception SelfStudyOverPersonalException 자습신청 인원이 50명이 넘었을 때
      * @exception
      * @exception
      * @author 배태현
@@ -46,8 +46,8 @@ public class SelfStudyServiceImpl implements SelfStudyService {
     @Override
     @Transactional
     public void requestSelfStudy(DayOfWeek dayOfWeek, int hour) {
-        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new IllegalArgumentException("자습신청이 가능한 요일이 아닙니다.");
-        if (!(hour >= 20 && hour < 23)) throw new IllegalArgumentException("오후 8시부터 오후 10시까지만 자습신청이 가능합니다."); // 20시(8시)부터 22시(10시) 사이가 아니라면 자습신청 불가능
+//        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new IllegalArgumentException("자습신청이 가능한 요일이 아닙니다.");
+//        if (!(hour >= 20 && hour < 23)) throw new IllegalArgumentException("오후 8시부터 오후 10시까지만 자습신청이 가능합니다."); // 20시(8시)부터 22시(10시) 사이가 아니라면 자습신청 불가능
 
         Member currentUser = currentUserUtil.getCurrentUser();
 
@@ -57,9 +57,9 @@ public class SelfStudyServiceImpl implements SelfStudyService {
                 count += 1;
                 log.info("Current Self Study Student Count is {}", count);
             } else
-                throw new SelfStudyCantApplied();
+                throw new SelfStudyCantAppliedException();
         } else
-            throw new SelfStudyOverPersonal();
+            throw new SelfStudyOverPersonalException();
     }
 
     /**
@@ -69,14 +69,14 @@ public class SelfStudyServiceImpl implements SelfStudyService {
      * 자습신청을 취소할 시 그 날 자습신청 불가능
      * @param dayOfWeek 현재 요일
      * @param hour 현재 시
-     * @exception SelfStudyCantChange 자습신청 상태가 APPLIED(신청됨)가 아닐 때 (자습신청 취소를 할 수 없는 상태)
+     * @exception SelfStudyCantChangeException 자습신청 상태가 APPLIED(신청됨)가 아닐 때 (자습신청 취소를 할 수 없는 상태)
      * @author 배태현
      */
     @Override
     @Transactional
     public void cancelSelfStudy(DayOfWeek dayOfWeek, int hour) {
-        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new IllegalArgumentException("자습신청 취소가 가능한 요일이 아닙니다.");
-        if (!(hour >= 20 && hour < 23)) throw new IllegalArgumentException("오후 8시부터 오후 10시까지만 자습신청 취소가 가능합니다."); // 20시(8시)부터 22시(10시) 사이가 아니라면 자습신청 취소 불가능
+//        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new IllegalArgumentException("자습신청 취소가 가능한 요일이 아닙니다.");
+//        if (!(hour >= 20 && hour < 23)) throw new IllegalArgumentException("오후 8시부터 오후 10시까지만 자습신청 취소가 가능합니다."); // 20시(8시)부터 22시(10시) 사이가 아니라면 자습신청 취소 불가능
 
         Member currentUser = currentUserUtil.getCurrentUser();
 
@@ -85,20 +85,20 @@ public class SelfStudyServiceImpl implements SelfStudyService {
             count -= 1;
             log.info("Current Self Study Student Count is {}", count);
         } else
-            throw new SelfStudyCantChange();
+            throw new SelfStudyCantChangeException();
     }
 
     /**
      * 자습신청한 학생을 전체 조회하는 서비스로직 (로그인된 유저 사용가능)
      * @return List - SelfStudyStudentDto (id, stuNum, username)
-     * @exception SelfStudyNotFound 자습신청한 학생이 없을 때
+     * @exception SelfStudyNotFoundException 자습신청한 학생이 없을 때
      * @author 배태현
      */
     @Override
     public List<SelfStudyStudentsDto> getSelfStudyStudents() {
         List<SelfStudyStudentsDto> selfStudyAPLLIED = memberRepository.findBySelfStudyAPLLIED();
 
-        if (selfStudyAPLLIED.isEmpty()) throw new SelfStudyNotFound();
+        if (selfStudyAPLLIED.isEmpty()) throw new SelfStudyNotFoundException();
         return selfStudyAPLLIED;
     }
 

--- a/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
@@ -1,9 +1,6 @@
 package com.server.Dotori.model.member.service.selfstudy;
 
-import com.server.Dotori.exception.selfstudy.exception.SelfStudyCantAppliedException;
-import com.server.Dotori.exception.selfstudy.exception.SelfStudyCantChangeException;
-import com.server.Dotori.exception.selfstudy.exception.SelfStudyNotFoundException;
-import com.server.Dotori.exception.selfstudy.exception.SelfStudyOverPersonalException;
+import com.server.Dotori.exception.selfstudy.exception.*;
 import com.server.Dotori.exception.user.exception.UserNotFoundByClassException;
 import com.server.Dotori.model.member.Member;
 import com.server.Dotori.model.member.dto.SelfStudyStudentsDto;
@@ -37,17 +34,17 @@ public class SelfStudyServiceImpl implements SelfStudyService {
      * 자습신청 할 시 '신청함'으로 상태변경 <br>
      * @param dayOfWeek 현재 요일
      * @param hour 현재 시
+     * @exception SelfStudyCantRequestDateException 금요일, 토요일, 일요일에 자습신청을 했을 때
+     * @exception SelfStudyCantRequestTimeException 오후 8시에서 오후 10시 사이가 아닌 시간에 자습신청을 했을 때
      * @exception SelfStudyCantAppliedException 자습신청 상태가 CAN(가능)이 아닐 때 (자습신청을 할 수 없는 상태)
      * @exception SelfStudyOverPersonalException 자습신청 인원이 50명이 넘었을 때
-     * @exception
-     * @exception
      * @author 배태현
      */
     @Override
     @Transactional
     public void requestSelfStudy(DayOfWeek dayOfWeek, int hour) {
-//        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new IllegalArgumentException("자습신청이 가능한 요일이 아닙니다.");
-//        if (!(hour >= 20 && hour < 23)) throw new IllegalArgumentException("오후 8시부터 오후 10시까지만 자습신청이 가능합니다."); // 20시(8시)부터 22시(10시) 사이가 아니라면 자습신청 불가능
+        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new SelfStudyCantRequestDateException();
+        if (!(hour >= 20 && hour < 23)) throw new SelfStudyCantRequestTimeException(); // 20시(8시)부터 22시(10시) 사이가 아니라면 자습신청 불가능
 
         Member currentUser = currentUserUtil.getCurrentUser();
 
@@ -69,14 +66,16 @@ public class SelfStudyServiceImpl implements SelfStudyService {
      * 자습신청을 취소할 시 그 날 자습신청 불가능
      * @param dayOfWeek 현재 요일
      * @param hour 현재 시
+     * @exception SelfStudyCantCancelDateException 금요일, 토요일, 일요일에 자습신청 취소를 했을 때
+     * @exception SelfStudyCantCancelTimeException 오후 8시에서 오후 10시 사이가 아닌 시간에 자습신청 취소를 했을 때
      * @exception SelfStudyCantChangeException 자습신청 상태가 APPLIED(신청됨)가 아닐 때 (자습신청 취소를 할 수 없는 상태)
      * @author 배태현
      */
     @Override
     @Transactional
     public void cancelSelfStudy(DayOfWeek dayOfWeek, int hour) {
-//        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new IllegalArgumentException("자습신청 취소가 가능한 요일이 아닙니다.");
-//        if (!(hour >= 20 && hour < 23)) throw new IllegalArgumentException("오후 8시부터 오후 10시까지만 자습신청 취소가 가능합니다."); // 20시(8시)부터 22시(10시) 사이가 아니라면 자습신청 취소 불가능
+        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new SelfStudyCantCancelDateException();
+        if (!(hour >= 20 && hour < 23)) throw new SelfStudyCantCancelTimeException(); // 20시(8시)부터 22시(10시) 사이가 아니라면 자습신청 취소 불가능
 
         Member currentUser = currentUserUtil.getCurrentUser();
 

--- a/src/main/java/com/server/Dotori/model/music/service/MusicServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/music/service/MusicServiceImpl.java
@@ -1,6 +1,7 @@
 package com.server.Dotori.model.music.service;
 
 import com.server.Dotori.exception.music.exception.MusicAlreadyException;
+import com.server.Dotori.exception.music.exception.MusicCantRequestDateException;
 import com.server.Dotori.exception.music.exception.MusicNotAppliedException;
 import com.server.Dotori.exception.music.exception.MusicNotFoundException;
 import com.server.Dotori.model.member.Member;
@@ -30,15 +31,15 @@ public class MusicServiceImpl implements MusicService {
      * 금요일, 토요일에는 음악신청 불가능
      * @param musicApplicationDto musicApplicationDto (musicUrl)
      * @param dayOfWeek 현재 요일
+     * @exception MusicCantRequestDateException 금요일, 토요일에 음악신청을 했을 때
      * @exception MusicAlreadyException 음악신청 상태가 CAN이 아닐 때
-     * @exception
      * @return Music
      * @author 배태현
      */
     @Override
     @Transactional
     public Music musicApplication(MusicApplicationDto musicApplicationDto, DayOfWeek dayOfWeek) {
-        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY) throw new IllegalArgumentException("음악신청을 하실 수 없는 요일입니다.");
+        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY) throw new MusicCantRequestDateException();
 
         Member currentUser = currentUserUtil.getCurrentUser();
 

--- a/src/test/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceTest.java
@@ -1,5 +1,9 @@
 package com.server.Dotori.model.member.service.selfstudy;
 
+import com.server.Dotori.exception.selfstudy.exception.SelfStudyCantCancelDateException;
+import com.server.Dotori.exception.selfstudy.exception.SelfStudyCantCancelTimeException;
+import com.server.Dotori.exception.selfstudy.exception.SelfStudyCantRequestDateException;
+import com.server.Dotori.exception.selfstudy.exception.SelfStudyCantRequestTimeException;
 import com.server.Dotori.model.member.Member;
 import com.server.Dotori.model.member.dto.MemberDto;
 import com.server.Dotori.model.member.enumType.Role;
@@ -78,12 +82,40 @@ class SelfStudyServiceTest {
     }
 
     @Test
+    @DisplayName("적절한 날짜 혹은 시간이 아닐 때 자습신청을 하면 예외가 제대로 터지나요?")
+    public void requestSelfStudyExceptionTest() {
+        assertThrows(
+                SelfStudyCantRequestDateException.class,
+                () -> selfStudyService.requestSelfStudy(DayOfWeek.FRIDAY, 21)
+        );
+
+        assertThrows(
+                SelfStudyCantRequestTimeException.class,
+                () -> selfStudyService.requestSelfStudy(DayOfWeek.MONDAY, 19)
+        );
+    }
+
+    @Test
     @DisplayName("자습신청 취소가 제대로 되나요?")
     public void cancelSelfStudy() {
         selfStudyService.requestSelfStudy(DayOfWeek.MONDAY, 21);
         selfStudyService.cancelSelfStudy(DayOfWeek.MONDAY, 21);
 
         assertEquals(CANT, currentUserUtil.getCurrentUser().getSelfStudy());
+    }
+
+    @Test
+    @DisplayName("적절한 날짜 혹은 시간이 아닐 때 자습신청 취소를 하면 예외가 제대로 터지나요?")
+    public void cancelSelfStudyExceptionTest() {
+        assertThrows(
+                SelfStudyCantCancelDateException.class,
+                () -> selfStudyService.cancelSelfStudy(DayOfWeek.FRIDAY, 21)
+        );
+
+        assertThrows(
+                SelfStudyCantCancelTimeException.class,
+                () -> selfStudyService.cancelSelfStudy(DayOfWeek.MONDAY, 19)
+        );
     }
 
     @Test

--- a/src/test/java/com/server/Dotori/model/music/service/MusicServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/music/service/MusicServiceTest.java
@@ -1,5 +1,6 @@
 package com.server.Dotori.model.music.service;
 
+import com.server.Dotori.exception.music.exception.MusicCantRequestDateException;
 import com.server.Dotori.model.member.Member;
 import com.server.Dotori.model.member.dto.MemberDto;
 import com.server.Dotori.model.member.enumType.Role;
@@ -86,6 +87,20 @@ class MusicServiceTest {
         //then
         assertThat(music.getMember().getMusic()).isEqualTo(APPLIED);
         assertThat(music.getUrl()).isEqualTo("https://www.youtube.com/watch?v=6h9qmKWK6Io");
+    }
+
+    @Test
+    @DisplayName("음악을 신청할 수 없는 요일에 신청했을 때 예외가 터지나요?")
+    public void musicApplicationExceptionTest() {
+        assertThrows(
+                MusicCantRequestDateException.class,
+                () -> musicService.musicApplication(
+                        MusicApplicationDto.builder()
+                                .musicUrl("https://www.youtube.com/watch?v=6h9qmKWK6Io")
+                                .build(),
+                        DayOfWeek.FRIDAY // 금요일
+                )
+        );
     }
 
     @Test


### PR DESCRIPTION
### 제가 한 일이에요 !
* 자습신청 / 취소,  추가(변경)된 Exception에 맞게 추가(변경)
* 기상음악 신청 추가된 Exception에 맞게 추가
* 자습신청/취소, 기상음악 알맞지 않은 시간에 요청이 들어왔을 때 예외가 터지는지 테스트코드로 검증

### swagger에서 확인한 결과
* 자습신청
![스크린샷 2021-10-18 오후 1 31 21](https://user-images.githubusercontent.com/69895394/137671825-b19c99d2-8eb6-4920-bf74-46527ce4e65b.png)
![스크린샷 2021-10-18 오후 1 32 54](https://user-images.githubusercontent.com/69895394/137671821-35b4f59e-deda-4d7e-a064-e6af7a6f3fab.png)
---

* 자습신청 취소
![스크린샷 2021-10-18 오후 1 31 18](https://user-images.githubusercontent.com/69895394/137671934-786ef72a-9772-49c1-828e-bd33e946368a.png)
![스크린샷 2021-10-18 오후 1 32 59](https://user-images.githubusercontent.com/69895394/137671822-9cfd7faf-cf0a-4dfa-b5fc-019c090158d3.png)
---

* 기상음악 신청
![스크린샷 2021-10-18 오후 1 43 12](https://user-images.githubusercontent.com/69895394/137671818-22169a37-b03a-43b3-9f49-0ea8c4beed01.png)