### PR TITLE
자습신청 수 카운트 다른 상황

### DIFF
--- a/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
@@ -25,7 +25,7 @@ public class SelfStudyServiceImpl implements SelfStudyService {
     private final CurrentUserUtil currentUserUtil;
     private final MemberRepository memberRepository;
 
-    int count = 0;
+    static int count = 0;
 
     /**
      * 자습 신청 서비스로직 (로그인 된 유저 사용가능) <br>
@@ -52,7 +52,7 @@ public class SelfStudyServiceImpl implements SelfStudyService {
         if (count <= 50){
             if (currentUser.getSelfStudy() == CAN) {
                 currentUser.updateSelfStudy(APPLIED);
-                count += 1;
+                count++;
                 log.info("Current Self Study Student Count is {}", count);
             } else
                 throw new SelfStudyCantAppliedException();
@@ -82,7 +82,7 @@ public class SelfStudyServiceImpl implements SelfStudyService {
 
         if (currentUser.getSelfStudy() == APPLIED) {
             currentUser.updateSelfStudy(CANT);
-            count -= 1;
+            count--;
             log.info("Current Self Study Student Count is {}", count);
         } else
             throw new SelfStudyCantChangeException();


### PR DESCRIPTION
### 제가 한 일이에요 !
* count 변수에 static 추가
> 현재 자습신청자의 실제 명수와 카운트 수가 다르게 나오고 있습니다.
저의 예상으로는 **`static`으로 설정하면 같은 곳의 메모리 주소만을 바라보기 때문**에 
**static 변수의 값을 공유 공유변수로 사용**하면 문제가 생기지 않을 것 같습니다. `(예상)`
> 
> **각자 따로 생성한 객체의 변수가 아니라 
접근하는 변수가 독립적인 값을 가지고 있을 것 같진 않지만**
> 
> 일단 PR 날려봅니다. 배포하고 또 봐봅시다 ! 🥲

현재 2명의 유저를 로그인 시켜 테스트 해 보았습니다.
정상적으로 잘 작동하는 상태 입니다.