### PR TITLE
운영서버와 개발서버의 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,7 @@ out/
 
 ### application.yml
 /src/main/resources/application.yml
+/src/main/resources/application-prod.yml
+/src/main/resources/application-dev.yml
 ### application.yml - test
 /src/test/resources/application.yml

--- a/src/main/java/com/server/Dotori/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/server/Dotori/config/swagger/SwaggerConfig.java
@@ -2,6 +2,7 @@ package com.server.Dotori.config.swagger;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
@@ -12,6 +13,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @Configuration
 @EnableSwagger2
+@Profile(value = {"dev"})
 public class SwaggerConfig {
 
     private ApiInfo apiInfo() {


### PR DESCRIPTION
### 운영서버와 개발서버를 분리하였습니다.
* 운영서버
   Swagger 접근 차단, h2에서 RDS로 변경

* 개발서버
   Swagger를 dev profile에서만 접근 허용, h2 사용
   
* ### IntelliJ Profile 변경법
 
  상단 메뉴에서 Run을 클릭합니다

<img width="700" alt="스크린샷 2021-12-14 17 10 26" src="https://user-images.githubusercontent.com/69895452/145958386-3bd9e82b-39ac-46ee-809e-8b98bb4edcbd.png">

* ####   그 후 Edit configurations를 클릭합니다.

<img width="700" alt="스크린샷 2021-12-14 17 12 38" src="https://user-images.githubusercontent.com/69895452/145958748-3f2bba8f-82f5-43f2-9bc9-6abb6b8ad6ff.png">

* ####   Active Profiles: 텍스트 칸에 개발서버(dev), 운영서버(prod)를 상황에 맞게 입력해 쓰시면 됩니다. 현재 저는 운영서버인 prod입니다. 

