### PR TITLE
CI/CD 구축 완료

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Deploy to EB # (2)
         uses: einaregilsson/beanstalk-deploy@v20
         with:
-          aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_access_key: ${{ secrets.IAM_ACCESS_KEY }}
+          aws_secret_key: ${{ secrets.IAM_SECRET_KEY }}
           application_name: Dotori-application
           environment_name: Dotori-application
           version_label: github-action-${{steps.current-time.outputs.formattedTime}}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,7 +68,7 @@ jobs:
           aws_access_key: ${{ secrets.IAM_ACCESS_KEY }}
           aws_secret_key: ${{ secrets.IAM_SECRET_KEY }}
           application_name: Dotori-server
-          environment_name: Dotori-server
+          environment_name: Dotoriserver-env
           version_label: github-action-${{steps.current-time.outputs.formattedTime}}
           region: ap-northeast-2
           deployment_package: deploy/application.jar

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -72,6 +72,7 @@ jobs:
           version_label: github-action-${{steps.current-time.outputs.formattedTime}}
           region: ap-northeast-2
           deployment_package: deploy/application.jar
+          wait_for_environment_recovery: 180
 
       - name: action-slack
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,7 @@ on:
     branches: [ feature/github-action-cd ]
 
 jobs:
-  build:
+  CD:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: Java CD with Gradle
 
 on:
   push:
-    branches: [ feature/github-action-cd ]
+    branches: [ master ]
 
 jobs:
   CD:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -67,8 +67,8 @@ jobs:
         with:
           aws_access_key: ${{ secrets.IAM_ACCESS_KEY }}
           aws_secret_key: ${{ secrets.IAM_SECRET_KEY }}
-          application_name: Dotori-application
-          environment_name: Dotori-application
+          application_name: Dotoriserver-env
+          environment_name: Dotoriserver-env
           version_label: github-action-${{steps.current-time.outputs.formattedTime}}
           region: ap-northeast-2
           deployment_package: deploy/application.jar

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,6 +59,7 @@ jobs:
 
       - name: Generate deployment package # (1)
         run: |
+          mkdir -p deploy
           cp build/libs/Dotori-0.0.1-SNAPSHOT.jar deploy/application.jar
 
       - name: Deploy to EB # (2)

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,82 @@
+name: Java CD with Gradle
+
+on:
+  push:
+    branches: [ feature/github-action-cd ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          cache: gradle
+
+      - name: AWS configure-aws-credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.IAM_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.IAM_SECRET_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Create application.yml
+        run: |
+          mkdir -p ./src/main/resources
+          mkdir -p ./src/test/resources
+          aws s3 cp s3://elasticbeanstalk-ap-northeast-2-340839260993/yml/application.yml ./src/main/resources/application.yml
+          aws s3 cp s3://elasticbeanstalk-ap-northeast-2-340839260993/yml/application-dev.yml ./src/main/resources/application-dev.yml
+          aws s3 cp s3://elasticbeanstalk-ap-northeast-2-340839260993/yml/application-prod.yml ./src/main/resources/application-prod.yml
+          aws s3 cp s3://elasticbeanstalk-ap-northeast-2-340839260993/yml/application-test.yml ./src/test/resources/application.yml
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Build with Gradle
+        run: ./gradlew clean build
+
+      - name: Get current time
+        uses: 1466587594/get-current-time@v2
+        id: current-time
+        with:
+          format: YYYY-MM-DDTHH-mm-ss
+          utcOffset: "+09:00"
+
+      - name: Generate deployment package # (1)
+        run: |
+          cp build/libs/Dotori-0.0.1-SNAPSHOT.jar deploy/application.jar
+
+      - name: Deploy to EB # (2)
+        uses: einaregilsson/beanstalk-deploy@v20
+        with:
+          aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          application_name: Dotori-application
+          environment_name: Dotori-application
+          version_label: github-action-${{steps.current-time.outputs.formattedTime}}
+          region: ap-northeast-2
+          deployment_package: deploy/application.jar
+
+      - name: action-slack
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took,pullRequest
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: always()

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -67,8 +67,8 @@ jobs:
         with:
           aws_access_key: ${{ secrets.IAM_ACCESS_KEY }}
           aws_secret_key: ${{ secrets.IAM_SECRET_KEY }}
-          application_name: Dotoriserver-env
-          environment_name: Dotoriserver-env
+          application_name: Dotori-server
+          environment_name: Dotori-server
           version_label: github-action-${{steps.current-time.outputs.formattedTime}}
           region: ap-northeast-2
           deployment_package: deploy/application.jar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master, develop ]
 
 jobs:
-  build:
+  CI:
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
### 제가 한 일이에요 !
* CI/CD 구축 완료

develop 브랜치에 PR을 날렸을 때 빌드 -> 결과는 슬랙 알람으로 오며 깃헙 PR창에서도 표시됩니다. 
> (PR을 날린 상태에서 커밋하면 커밋 할 때 또 PR을 날리지 않아도 빌드가 됩니다, <- 이건 설정한게 아닌 자동 (develop으로 PR날리는걸로 인식하는 것 같아요, 편함)

develop 브랜치에 merge 되었을 때 빌드
master 브랜치에 PR 날렸을 때 빌드
master 브랜치에 merge되었을 때 CD (이번 PR에서 적용시킨 기능입니다 !)

저희 build 결과는 슬랙, github에서도 표시되니 앞으로 라벨에 빌드 결과를 달지 않아도 될 것 같아요 !

### CD 결과
![스크린샷 2021-12-22 오전 8 42 31](https://user-images.githubusercontent.com/69895394/147011644-cb814111-4cbe-400e-ad83-48a6261f3e92.png)

<img width="635" alt="스크린샷 2021-12-22 오전 8 41 18" src="https://user-images.githubusercontent.com/69895394/147011530-50e72235-a7a7-480f-b72a-7acbeb7cb649.png">

![스크린샷 2021-12-22 오전 8 43 02](https://user-images.githubusercontent.com/69895394/147011640-bb82522d-e65b-46a0-a1ee-0ef7c7ee4acc.png)

> 자세한 결과는 [action](https://github.com/Team-Ampersand/Dotori-server/actions)에서 확인해주세요