### PR TITLE
자습신청 가능 시간 오류 수정

### DIFF
--- a/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
@@ -46,7 +46,7 @@ public class SelfStudyServiceImpl implements SelfStudyService {
     @Transactional
     public void requestSelfStudy(DayOfWeek dayOfWeek, int hour) {
 //        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new SelfStudyCantRequestDateException();
-//        if (!(hour >= 20 && hour < 23)) throw new SelfStudyCantRequestTimeException(); // 20시(8시)부터 22시(10시) 사이가 아니라면 자습신청 불가능
+//        if (!(hour >= 20 && hour < 22)) throw new SelfStudyCantRequestTimeException(); // 20시(8시)부터 22시(10시 (9시 59분)) 사이가 아니라면 자습신청 불가능
 
         Member currentUser = currentUserUtil.getCurrentUser();
         long count = selfStudyRepository.count();
@@ -82,7 +82,7 @@ public class SelfStudyServiceImpl implements SelfStudyService {
     @Transactional
     public void cancelSelfStudy(DayOfWeek dayOfWeek, int hour) {
 //        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new SelfStudyCantCancelDateException();
-//        if (!(hour >= 20 && hour < 23)) throw new SelfStudyCantCancelTimeException(); // 20시(8시)부터 22시(10시) 사이가 아니라면 자습신청 취소 불가능
+//        if (!(hour >= 20 && hour < 22)) throw new SelfStudyCantCancelTimeException(); // 20시(8시)부터 22시(10시 (9시 59분)) 사이가 아니라면 자습신청 취소 불가능
 
         Member currentUser = currentUserUtil.getCurrentUser();
         long count = selfStudyRepository.count();


### PR DESCRIPTION
### 제가 한 일이에요 !
* 자습신청 가능 시간 오류 수정
> 원래였다면 10시 59분까지 자습신청이 가능했습니다
-> 9시 59분까지만 자습신청이 가능하게 변경되었습니다.