### PR TITLE
9시까지만 자습신청 할 수 있게 변경

### DIFF
--- a/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
@@ -32,12 +32,12 @@ public class SelfStudyServiceImpl implements SelfStudyService {
      * 자습 신청 서비스로직 (로그인 된 유저 사용가능) <br>
      * 50명까지 신청 가능, 자습신청 상태가 '가능'인 사람만 신청가능 <br>
      * 금요일, 토요일, 일요일에는 자습신청 불가능 <br>
-     * 위 요일을 제외한 나머지 요일에는 오후 8시부터 오후 10시까지만 자습신청 가능 <br>
+     * 위 요일을 제외한 나머지 요일에는 오후 8시부터 오후 9시까지만 자습신청 가능 <br>
      * 자습신청 할 시 '신청함'으로 상태변경 <br>
      * @param dayOfWeek 현재 요일
      * @param hour 현재 시
      * @exception SelfStudyCantRequestDateException 금요일, 토요일, 일요일에 자습신청을 했을 때
-     * @exception SelfStudyCantRequestTimeException 오후 8시에서 오후 10시 사이가 아닌 시간에 자습신청을 했을 때
+     * @exception SelfStudyCantRequestTimeException 오후 8시에서 오후 9시 사이가 아닌 시간에 자습신청을 했을 때
      * @exception SelfStudyCantAppliedException 자습신청 상태가 CAN(가능)이 아닐 때 (자습신청을 할 수 없는 상태)
      * @exception SelfStudyOverPersonalException 자습신청 인원이 50명이 넘었을 때
      * @author 배태현
@@ -46,7 +46,7 @@ public class SelfStudyServiceImpl implements SelfStudyService {
     @Transactional
     public void requestSelfStudy(DayOfWeek dayOfWeek, int hour) {
         if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new SelfStudyCantRequestDateException();
-        if (!(hour >= 20 && hour < 22)) throw new SelfStudyCantRequestTimeException(); // 20시(8시)부터 22시(10시 (9시 59분)) 사이가 아니라면 자습신청 불가능
+        if (!(hour >= 20 && hour < 21)) throw new SelfStudyCantRequestTimeException(); // 20시(8시)부터 22시(9시 (8시 59분)) 사이가 아니라면 자습신청 불가능
 
         Member currentUser = currentUserUtil.getCurrentUser();
         long count = selfStudyRepository.count();
@@ -74,7 +74,7 @@ public class SelfStudyServiceImpl implements SelfStudyService {
      * @param dayOfWeek 현재 요일
      * @param hour 현재 시
      * @exception SelfStudyCantCancelDateException 금요일, 토요일, 일요일에 자습신청 취소를 했을 때
-     * @exception SelfStudyCantCancelTimeException 오후 8시에서 오후 10시 사이가 아닌 시간에 자습신청 취소를 했을 때
+     * @exception SelfStudyCantCancelTimeException 오후 8시에서 오후 9시 사이가 아닌 시간에 자습신청 취소를 했을 때
      * @exception SelfStudyCantChangeException 자습신청 상태가 APPLIED(신청됨)가 아닐 때 (자습신청 취소를 할 수 없는 상태)
      * @author 배태현
      */
@@ -82,7 +82,7 @@ public class SelfStudyServiceImpl implements SelfStudyService {
     @Transactional
     public void cancelSelfStudy(DayOfWeek dayOfWeek, int hour) {
         if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new SelfStudyCantCancelDateException();
-        if (!(hour >= 20 && hour < 22)) throw new SelfStudyCantCancelTimeException(); // 20시(8시)부터 22시(10시 (9시 59분)) 사이가 아니라면 자습신청 취소 불가능
+        if (!(hour >= 20 && hour < 21)) throw new SelfStudyCantCancelTimeException(); // 20시(8시)부터 22시(9시 (8시 59분)) 사이가 아니라면 자습신청 취소 불가능
 
         Member currentUser = currentUserUtil.getCurrentUser();
         long count = selfStudyRepository.count();

--- a/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
@@ -46,7 +46,7 @@ public class SelfStudyServiceImpl implements SelfStudyService {
     @Transactional
     public void requestSelfStudy(DayOfWeek dayOfWeek, int hour) {
         if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new SelfStudyCantRequestDateException();
-        if (!(hour >= 20 && hour < 21)) throw new SelfStudyCantRequestTimeException(); // 20시(8시)부터 22시(9시 (8시 59분)) 사이가 아니라면 자습신청 불가능
+        if (!(hour >= 20 && hour < 21)) throw new SelfStudyCantRequestTimeException(); // 20시(8시)부터 21시(9시 (8시 59분)) 사이가 아니라면 자습신청 불가능
 
         Member currentUser = currentUserUtil.getCurrentUser();
         long count = selfStudyRepository.count();
@@ -82,7 +82,7 @@ public class SelfStudyServiceImpl implements SelfStudyService {
     @Transactional
     public void cancelSelfStudy(DayOfWeek dayOfWeek, int hour) {
         if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new SelfStudyCantCancelDateException();
-        if (!(hour >= 20 && hour < 21)) throw new SelfStudyCantCancelTimeException(); // 20시(8시)부터 22시(9시 (8시 59분)) 사이가 아니라면 자습신청 취소 불가능
+        if (!(hour >= 20 && hour < 21)) throw new SelfStudyCantCancelTimeException(); // 20시(8시)부터 21시(9시 (8시 59분)) 사이가 아니라면 자습신청 취소 불가능
 
         Member currentUser = currentUserUtil.getCurrentUser();
         long count = selfStudyRepository.count();

--- a/src/test/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceTest.java
@@ -76,7 +76,7 @@ class SelfStudyServiceTest {
     @Test
     @DisplayName("자습신청이 제대로 되나요?")
     public void requestSelfStudyTest() {
-        selfStudyService.requestSelfStudy(DayOfWeek.MONDAY, 21); // 월요일 9시
+        selfStudyService.requestSelfStudy(DayOfWeek.MONDAY, 20); // 월요일 8시
 
         assertEquals(SelfStudy.APPLIED, currentUserUtil.getCurrentUser().getSelfStudy());
         assertEquals(1 , selfStudyRepository.findAll().size());
@@ -88,7 +88,7 @@ class SelfStudyServiceTest {
     public void requestSelfStudyExceptionTest() {
         assertThrows(
                 SelfStudyCantRequestDateException.class,
-                () -> selfStudyService.requestSelfStudy(DayOfWeek.FRIDAY, 21)
+                () -> selfStudyService.requestSelfStudy(DayOfWeek.FRIDAY, 20)
         );
 
         assertThrows(
@@ -100,8 +100,8 @@ class SelfStudyServiceTest {
     @Test
     @DisplayName("자습신청 취소가 제대로 되나요?")
     public void cancelSelfStudy() {
-        selfStudyService.requestSelfStudy(DayOfWeek.MONDAY, 21);
-        selfStudyService.cancelSelfStudy(DayOfWeek.MONDAY, 21);
+        selfStudyService.requestSelfStudy(DayOfWeek.MONDAY, 20);
+        selfStudyService.cancelSelfStudy(DayOfWeek.MONDAY, 20);
 
         assertEquals(CANT, currentUserUtil.getCurrentUser().getSelfStudy());
         assertEquals(0, selfStudyRepository.count());
@@ -113,7 +113,7 @@ class SelfStudyServiceTest {
     public void cancelSelfStudyExceptionTest() {
         assertThrows(
                 SelfStudyCantCancelDateException.class,
-                () -> selfStudyService.cancelSelfStudy(DayOfWeek.FRIDAY, 21)
+                () -> selfStudyService.cancelSelfStudy(DayOfWeek.FRIDAY, 20)
         );
 
         assertThrows(
@@ -126,7 +126,7 @@ class SelfStudyServiceTest {
     @DisplayName("자습 신청한 학생들 목록이 잘 조회 되나요?")
     public void getSelfStudyStudents() {
         //given //when
-        selfStudyService.requestSelfStudy(DayOfWeek.MONDAY, 21);
+        selfStudyService.requestSelfStudy(DayOfWeek.MONDAY, 20);
         List<SelfStudyStudentsDto> selfStudyStudents = selfStudyService.getSelfStudyStudents();
 
         //then
@@ -137,7 +137,7 @@ class SelfStudyServiceTest {
     @DisplayName("자습신청한 학생들의 목록이 학년반별 카테고리 목록으로 조회 되나요?")
     public void getSelfStudyStudentsCategoryTest() {
         //given //when
-        selfStudyService.requestSelfStudy(DayOfWeek.MONDAY, 21);
+        selfStudyService.requestSelfStudy(DayOfWeek.MONDAY, 20);
         List<SelfStudyStudentsDto> selfStudyStudentsByCategory = selfStudyService.getSelfStudyStudentsByCategory(24L);
 
         //then
@@ -204,7 +204,7 @@ class SelfStudyServiceTest {
     @DisplayName("자습신청한 학생 수 카운트가 잘 세지나요?")
     public void selfStudyCountTest() {
         //given //when
-        selfStudyService.requestSelfStudy(DayOfWeek.MONDAY, 21);
+        selfStudyService.requestSelfStudy(DayOfWeek.MONDAY, 20);
 
         Map<String, String> selfStudyInfo = selfStudyService.selfStudyInfo();
 


### PR DESCRIPTION
### 제가 한 일이에요 ! 
* 자습신청을 9시까지만 할 수 있게 변경
    * 이에 따른 테스트코드 변경

### 중요
> 이 PR이 merge되고 새벽에 잠수함패치로 적용되어도 
아직 프론트에서 자습신청 가능시간이 바뀌지 않아있습니다.
프론트에서 작업완료 된 후 aws서버에 적용하기 위해 
프론트에서 작업 완료되면 develop branch로 merge해주시길 바랍니다.
