### PR TITLE
해당 날짜에 신청된 기상음악 조회

### DIFF
--- a/src/main/java/com/server/Dotori/model/member/controller/studentinfo/admin/AdminStuInfoController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/studentinfo/admin/AdminStuInfoController.java
@@ -33,7 +33,7 @@ public class AdminStuInfoController {
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
-    public SingleResult getStudentInfo() {
+    public SingleResult getAllStudentInfoAdmin() {
         return responseService.getSingleResult(stuInfoService.getAllStudentInfo());
     }
 

--- a/src/main/java/com/server/Dotori/model/member/controller/studentinfo/councillor/CouncillorStuInfoController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/studentinfo/councillor/CouncillorStuInfoController.java
@@ -33,7 +33,7 @@ public class CouncillorStuInfoController {
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
-    public SingleResult getStudentInfo() {
+    public SingleResult getAllStudentInfoCouncillor() {
         return responseService.getSingleResult(stuInfoService.getAllStudentInfo());
     }
 

--- a/src/main/java/com/server/Dotori/model/member/controller/studentinfo/developer/DeveloperStuInfoController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/studentinfo/developer/DeveloperStuInfoController.java
@@ -33,7 +33,7 @@ public class DeveloperStuInfoController {
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
-    public SingleResult getStudentInfo() {
+    public SingleResult getAllStudentInfoDeveloper() {
         return responseService.getSingleResult(stuInfoService.getAllStudentInfo());
     }
 

--- a/src/main/java/com/server/Dotori/model/music/controller/admin/AdminMusicController.java
+++ b/src/main/java/com/server/Dotori/model/music/controller/admin/AdminMusicController.java
@@ -1,5 +1,6 @@
 package com.server.Dotori.model.music.controller.admin;
 
+import com.server.Dotori.model.music.dto.DateMusicDto;
 import com.server.Dotori.model.music.dto.MusicResDto;
 import com.server.Dotori.model.music.service.MusicService;
 import com.server.Dotori.response.ResponseService;
@@ -72,5 +73,16 @@ public class AdminMusicController {
     })
     public SingleResult<List<MusicResDto>> findCurrentDateMusicAdmin() {
         return responseService.getSingleResult(musicService.getCurrentDateMusic());
+    }
+
+    @PostMapping("/music/date")
+    @ResponseStatus( HttpStatus.OK )
+    @ApiOperation(value = "해당 날짜에 신청된 음악목록 조회", notes = "해당 날짜에 신청된 음악목록 조회")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
+    public SingleResult<List<MusicResDto>> findDateMusicMember(@RequestBody DateMusicDto dateMusicDto) {
+        return responseService.getSingleResult(musicService.getDateMusic(dateMusicDto.getDate()));
     }
 }

--- a/src/main/java/com/server/Dotori/model/music/controller/admin/AdminMusicController.java
+++ b/src/main/java/com/server/Dotori/model/music/controller/admin/AdminMusicController.java
@@ -75,6 +75,12 @@ public class AdminMusicController {
         return responseService.getSingleResult(musicService.getCurrentDateMusic());
     }
 
+    /**
+     * 특정 날짜에 신청된 음악목록을 조회하는 컨트롤러
+     * @param dateMusicDto date
+     * @return SingleResult - List - MusicResDto
+     * @author 배태현
+     */
     @PostMapping("/music/date")
     @ResponseStatus( HttpStatus.OK )
     @ApiOperation(value = "해당 날짜에 신청된 음악목록 조회", notes = "해당 날짜에 신청된 음악목록 조회")

--- a/src/main/java/com/server/Dotori/model/music/controller/admin/AdminMusicController.java
+++ b/src/main/java/com/server/Dotori/model/music/controller/admin/AdminMusicController.java
@@ -88,7 +88,7 @@ public class AdminMusicController {
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
-    public SingleResult<List<MusicResDto>> findDateMusicMember(@RequestBody DateMusicDto dateMusicDto) {
+    public SingleResult<List<MusicResDto>> findDateMusicAdmin(@RequestBody DateMusicDto dateMusicDto) {
         return responseService.getSingleResult(musicService.getDateMusic(dateMusicDto.getDate()));
     }
 }

--- a/src/main/java/com/server/Dotori/model/music/controller/councillor/CouncillorMusicController.java
+++ b/src/main/java/com/server/Dotori/model/music/controller/councillor/CouncillorMusicController.java
@@ -95,6 +95,12 @@ public class CouncillorMusicController {
         return responseService.getSingleResult(musicService.getCurrentDateMusic());
     }
 
+    /**
+     * 특정 날짜에 신청된 음악목록을 조회하는 컨트롤러
+     * @param dateMusicDto date
+     * @return SingleResult - List - MusicResDto
+     * @author 배태현
+     */
     @PostMapping("/music/date")
     @ResponseStatus( HttpStatus.OK )
     @ApiOperation(value = "해당 날짜에 신청된 음악목록 조회", notes = "해당 날짜에 신청된 음악목록 조회")

--- a/src/main/java/com/server/Dotori/model/music/controller/councillor/CouncillorMusicController.java
+++ b/src/main/java/com/server/Dotori/model/music/controller/councillor/CouncillorMusicController.java
@@ -108,7 +108,7 @@ public class CouncillorMusicController {
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
-    public SingleResult<List<MusicResDto>> findDateMusicMember(@RequestBody DateMusicDto dateMusicDto) {
+    public SingleResult<List<MusicResDto>> findDateMusicCouncillor(@RequestBody DateMusicDto dateMusicDto) {
         return responseService.getSingleResult(musicService.getDateMusic(dateMusicDto.getDate()));
     }
 }

--- a/src/main/java/com/server/Dotori/model/music/controller/councillor/CouncillorMusicController.java
+++ b/src/main/java/com/server/Dotori/model/music/controller/councillor/CouncillorMusicController.java
@@ -1,5 +1,6 @@
 package com.server.Dotori.model.music.controller.councillor;
 
+import com.server.Dotori.model.music.dto.DateMusicDto;
 import com.server.Dotori.model.music.dto.MusicApplicationDto;
 import com.server.Dotori.model.music.dto.MusicResDto;
 import com.server.Dotori.model.music.service.MusicService;
@@ -92,5 +93,16 @@ public class CouncillorMusicController {
     })
     public SingleResult<List<MusicResDto>> findCurrentDateMusicCouncillor() {
         return responseService.getSingleResult(musicService.getCurrentDateMusic());
+    }
+
+    @PostMapping("/music/date")
+    @ResponseStatus( HttpStatus.OK )
+    @ApiOperation(value = "해당 날짜에 신청된 음악목록 조회", notes = "해당 날짜에 신청된 음악목록 조회")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
+    public SingleResult<List<MusicResDto>> findDateMusicMember(@RequestBody DateMusicDto dateMusicDto) {
+        return responseService.getSingleResult(musicService.getDateMusic(dateMusicDto.getDate()));
     }
 }

--- a/src/main/java/com/server/Dotori/model/music/controller/developer/DeveloperMusicController.java
+++ b/src/main/java/com/server/Dotori/model/music/controller/developer/DeveloperMusicController.java
@@ -108,7 +108,7 @@ public class DeveloperMusicController {
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
-    public SingleResult<List<MusicResDto>> findDateMusicMember(@RequestBody DateMusicDto dateMusicDto) {
+    public SingleResult<List<MusicResDto>> findDateMusicDeveloper(@RequestBody DateMusicDto dateMusicDto) {
         return responseService.getSingleResult(musicService.getDateMusic(dateMusicDto.getDate()));
     }
 }

--- a/src/main/java/com/server/Dotori/model/music/controller/developer/DeveloperMusicController.java
+++ b/src/main/java/com/server/Dotori/model/music/controller/developer/DeveloperMusicController.java
@@ -1,5 +1,6 @@
 package com.server.Dotori.model.music.controller.developer;
 
+import com.server.Dotori.model.music.dto.DateMusicDto;
 import com.server.Dotori.model.music.dto.MusicApplicationDto;
 import com.server.Dotori.model.music.dto.MusicResDto;
 import com.server.Dotori.model.music.service.MusicService;
@@ -92,5 +93,16 @@ public class DeveloperMusicController {
     })
     public SingleResult<List<MusicResDto>> findCurrentDateMusicDeveloper() {
         return responseService.getSingleResult(musicService.getCurrentDateMusic());
+    }
+
+    @PostMapping("/music/date")
+    @ResponseStatus( HttpStatus.OK )
+    @ApiOperation(value = "해당 날짜에 신청된 음악목록 조회", notes = "해당 날짜에 신청된 음악목록 조회")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
+    public SingleResult<List<MusicResDto>> findDateMusicMember(@RequestBody DateMusicDto dateMusicDto) {
+        return responseService.getSingleResult(musicService.getDateMusic(dateMusicDto.getDate()));
     }
 }

--- a/src/main/java/com/server/Dotori/model/music/controller/developer/DeveloperMusicController.java
+++ b/src/main/java/com/server/Dotori/model/music/controller/developer/DeveloperMusicController.java
@@ -95,6 +95,12 @@ public class DeveloperMusicController {
         return responseService.getSingleResult(musicService.getCurrentDateMusic());
     }
 
+    /**
+     * 특정 날짜에 신청된 음악목록을 조회하는 컨트롤러
+     * @param dateMusicDto date
+     * @return SingleResult - List - MusicResDto
+     * @author 배태현
+     */
     @PostMapping("/music/date")
     @ResponseStatus( HttpStatus.OK )
     @ApiOperation(value = "해당 날짜에 신청된 음악목록 조회", notes = "해당 날짜에 신청된 음악목록 조회")

--- a/src/main/java/com/server/Dotori/model/music/controller/member/MemberMusicController.java
+++ b/src/main/java/com/server/Dotori/model/music/controller/member/MemberMusicController.java
@@ -80,6 +80,12 @@ public class MemberMusicController {
         return responseService.getSingleResult(musicService.getCurrentDateMusic());
     }
 
+    /**
+     * 특정 날짜에 신청된 음악목록을 조회하는 컨트롤러
+     * @param dateMusicDto date
+     * @return SingleResult - List - MusicResDto
+     * @author 배태현
+     */
     @PostMapping("/music/date")
     @ResponseStatus( HttpStatus.OK )
     @ApiOperation(value = "해당 날짜에 신청된 음악목록 조회", notes = "해당 날짜에 신청된 음악목록 조회")

--- a/src/main/java/com/server/Dotori/model/music/controller/member/MemberMusicController.java
+++ b/src/main/java/com/server/Dotori/model/music/controller/member/MemberMusicController.java
@@ -1,5 +1,6 @@
 package com.server.Dotori.model.music.controller.member;
 
+import com.server.Dotori.model.music.dto.DateMusicDto;
 import com.server.Dotori.model.music.dto.MusicApplicationDto;
 import com.server.Dotori.model.music.dto.MusicResDto;
 import com.server.Dotori.model.music.service.MusicService;
@@ -77,5 +78,16 @@ public class MemberMusicController {
     })
     public SingleResult<List<MusicResDto>> findCurrentDateMusicMember() {
         return responseService.getSingleResult(musicService.getCurrentDateMusic());
+    }
+
+    @PostMapping("/music/date")
+    @ResponseStatus( HttpStatus.OK )
+    @ApiOperation(value = "해당 날짜에 신청된 음악목록 조회", notes = "해당 날짜에 신청된 음악목록 조회")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
+    public SingleResult<List<MusicResDto>> findDateMusicMember(@RequestBody DateMusicDto dateMusicDto) {
+        return responseService.getSingleResult(musicService.getDateMusic(dateMusicDto.getDate()));
     }
 }

--- a/src/main/java/com/server/Dotori/model/music/dto/DateMusicDto.java
+++ b/src/main/java/com/server/Dotori/model/music/dto/DateMusicDto.java
@@ -1,0 +1,12 @@
+package com.server.Dotori.model.music.dto;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
+public class DateMusicDto {
+
+    private LocalDate date;
+}

--- a/src/main/java/com/server/Dotori/model/music/dto/DateMusicDto.java
+++ b/src/main/java/com/server/Dotori/model/music/dto/DateMusicDto.java
@@ -2,11 +2,13 @@ package com.server.Dotori.model.music.dto;
 
 import lombok.*;
 
+import javax.validation.constraints.NotBlank;
 import java.time.LocalDate;
 
 @Getter @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
 public class DateMusicDto {
 
+    @NotBlank
     private LocalDate date;
 }

--- a/src/main/java/com/server/Dotori/model/music/repository/MusicRepositoryCustom.java
+++ b/src/main/java/com/server/Dotori/model/music/repository/MusicRepositoryCustom.java
@@ -12,4 +12,6 @@ public interface MusicRepositoryCustom {
     List<MusicResDto> findAllMusic();
 
     List<MusicResDto> findCurrentDateMusic(LocalDate localDate);
+
+    List<MusicResDto> findDateMusic(LocalDate date);
 }

--- a/src/main/java/com/server/Dotori/model/music/repository/MusicRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/model/music/repository/MusicRepositoryImpl.java
@@ -84,4 +84,19 @@ public class MusicRepositoryImpl implements MusicRepositoryCustom {
                 .orderBy(music.createdDate.asc())
                 .fetch();
     }
+
+    @Override
+    public List<MusicResDto> findDateMusic(LocalDate date) {
+        return queryFactory
+                .select(Projections.fields(MusicResDto.class,
+                        music.id,
+                        music.url,
+                        music.member.username,
+                        music.createdDate
+                ))
+                .from(music)
+                .where(music.createdDate.stringValue().like(date+"%"))
+                .orderBy(music.createdDate.asc())
+                .fetch();
+    }
 }

--- a/src/main/java/com/server/Dotori/model/music/repository/MusicRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/model/music/repository/MusicRepositoryImpl.java
@@ -85,6 +85,12 @@ public class MusicRepositoryImpl implements MusicRepositoryCustom {
                 .fetch();
     }
 
+    /**
+     * 해당하는 날짜에 신청된 음악을 조회하는 query
+     * @param date date
+     * @return List-MusicResDto (id, musicUrl, member.username)
+     * @author 배태현
+     */
     @Override
     public List<MusicResDto> findDateMusic(LocalDate date) {
         return queryFactory

--- a/src/main/java/com/server/Dotori/model/music/schedule/MusicSchedule.java
+++ b/src/main/java/com/server/Dotori/model/music/schedule/MusicSchedule.java
@@ -15,13 +15,23 @@ public class MusicSchedule {
 
     private final MusicService musicService;
 
+//    /**
+//     * "토요일 23시 59분"에 음악신청 목록을 자동으로 초기화해주는 Scheduled
+//     * @author 배태현
+//     */
+//    @Scheduled(cron = "0 59 23 ? * SAT")
+//    public void saturdayMusicDeleteAll() {
+//        musicService.saturdayMusicDeleteAll();
+//        log.info("Music Delete All At {}", new Date());
+//    }
+
     /**
-     * "토요일 23시 59분"에 음악신청 목록을 자동으로 초기화해주는 Scheduled
+     * 매 달 1일 새벽 4시에 음악신청 목록을 초기화해주는 Scheduled
      * @author 배태현
      */
-    @Scheduled(cron = "0 59 23 ? * SAT")
-    public void saturdayMusicDeleteAll() {
-        musicService.saturdayMusicDeleteAll();
+    @Scheduled(cron = "0 0 4 1 1/1 ?")
+    public void monthMusicDeleteAll() {
+        musicService.monthMusicDeleteAll();
         log.info("Music Delete All At {}", new Date());
     }
 

--- a/src/main/java/com/server/Dotori/model/music/service/MusicService.java
+++ b/src/main/java/com/server/Dotori/model/music/service/MusicService.java
@@ -1,10 +1,12 @@
 package com.server.Dotori.model.music.service;
 
 import com.server.Dotori.model.music.Music;
+import com.server.Dotori.model.music.dto.DateMusicDto;
 import com.server.Dotori.model.music.dto.MusicApplicationDto;
 import com.server.Dotori.model.music.dto.MusicResDto;
 
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -17,8 +19,10 @@ public interface MusicService {
     List<MusicResDto> getCurrentDateMusic();
 
     void deleteMusic(Long musicId);
+
+    List<MusicResDto> getDateMusic(LocalDate date);
   
     void updateMemberMusicStatus();
 
-    void saturdayMusicDeleteAll();
+    void monthMusicDeleteAll();
 }

--- a/src/main/java/com/server/Dotori/model/music/service/MusicServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/music/service/MusicServiceImpl.java
@@ -3,6 +3,7 @@ package com.server.Dotori.model.music.service;
 import com.server.Dotori.exception.music.exception.*;
 import com.server.Dotori.model.member.Member;
 import com.server.Dotori.model.music.Music;
+import com.server.Dotori.model.music.dto.DateMusicDto;
 import com.server.Dotori.model.music.dto.MusicApplicationDto;
 import com.server.Dotori.model.music.dto.MusicResDto;
 import com.server.Dotori.model.music.repository.MusicRepository;
@@ -99,6 +100,19 @@ public class MusicServiceImpl implements MusicService {
     }
 
     /**
+     * 날짜별로 신청된 음악을 조회하는 서비스 로직 (로그인 된 유저 사용가능)
+     * @param date date (2022-01-05)
+     * @return
+     */
+    @Override
+    public List<MusicResDto> getDateMusic(LocalDate date) {
+        List<MusicResDto> dateMusic = musicRepository.findDateMusic(date);
+
+        if (dateMusic.isEmpty()) throw new IllegalArgumentException("해당 날짜에 신청된 노래가 없습니다.");
+        return dateMusic;
+    }
+
+    /**
      * 음악신청된 회원의 음악신청 상태를 변경하는 서비스로직 (Scheduled)
      * @author 배태현
      */
@@ -113,7 +127,7 @@ public class MusicServiceImpl implements MusicService {
      * @author 배태현
      */
     @Override
-    public void saturdayMusicDeleteAll() {
+    public void monthMusicDeleteAll() {
         musicRepository.deleteAll();
     }
 }

--- a/src/test/java/com/server/Dotori/model/music/schedule/MusicScheduleTest.java
+++ b/src/test/java/com/server/Dotori/model/music/schedule/MusicScheduleTest.java
@@ -1,6 +1,7 @@
 package com.server.Dotori.model.music.schedule;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +19,7 @@ class MusicScheduleTest {
     private ScheduledTaskHolder scheduledTaskHolder;
 
     @Test
+    @Disabled
     @DisplayName("토요일에 모든 음악이 삭제되는 일정이 잘 예약되었는지 확인하는 테스트")
     public void saturdayMusicDeleteAllTest() {
         Set<ScheduledTask> scheduledTasks = scheduledTaskHolder.getScheduledTasks();
@@ -27,6 +29,20 @@ class MusicScheduleTest {
                 .filter(scheduledTask -> scheduledTask.getTask() instanceof CronTask)
                 .map(scheduledTask -> (CronTask) scheduledTask.getTask())
                 .filter(cronTask -> cronTask.getExpression().equals("0 59 23 ? * SAT") && cronTask.toString().equals("com.server.Dotori.model.music.schedule.MusicSchedule.saturdayMusicDeleteAll"))
+                .count();
+        Assertions.assertThat(count).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("매 달 1일 새벽 4시에 모든 음악이 삭제되는 일정이 잘 예약되었는지 확인하는 테스트")
+    public void monthMusicDeleteAllTest() {
+        Set<ScheduledTask> scheduledTasks = scheduledTaskHolder.getScheduledTasks();
+        scheduledTasks.forEach(scheduledTask -> scheduledTask.getTask().getRunnable().getClass().getDeclaredMethods());
+
+        long count = scheduledTasks.stream()
+                .filter(scheduledTask -> scheduledTask.getTask() instanceof CronTask)
+                .map(scheduledTask -> (CronTask) scheduledTask.getTask())
+                .filter(cronTask -> cronTask.getExpression().equals("0 0 4 1 1/1 ?") && cronTask.toString().equals("com.server.Dotori.model.music.schedule.MusicSchedule.monthMusicDeleteAll"))
                 .count();
         Assertions.assertThat(count).isEqualTo(1L);
     }

--- a/src/test/java/com/server/Dotori/model/music/service/MusicServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/music/service/MusicServiceTest.java
@@ -221,4 +221,19 @@ class MusicServiceTest {
         List<MusicResDto> currentDateMusic = musicService.getCurrentDateMusic();
         assertEquals(localDate, currentDateMusic.get(0).getCreatedDate().toString().substring(0, 10));
     }
+
+    @Test
+    @DisplayName("해당 날짜에 신청된 음악이 잘 조회되나요 ?")
+    public void findDateMusic() {
+        musicService.musicApplication(
+                MusicApplicationDto.builder()
+                        .musicUrl("https://www.youtube.com/watch?v=6h9qmKWK6Io")
+                        .build(),
+                DayOfWeek.MONDAY // 월요일
+        );
+
+        LocalDate date = LocalDate.now();
+
+        assertEquals(1, musicService.getDateMusic(date).size());
+    }
 }


### PR DESCRIPTION
### 제가 한 일이에요 !
* 해당 날짜에 신청된 기상음악 조회하는 기능 개발
     * 이에 해당하는 테스트코드 작성 
* 매 달 1일 새벽 4시에 한달간 신청된 음악 초기화
    * 새벽 4시에 초기화 하는 이유는 매 달 1일이 평일이고 12시에 초기화 된다고 가정하면 
    사감선생님이 새벽에 신청된 음악을 조회/플레이리스트에 넣으시려고 할 때 신청된 음악이 없는 경우가 발생할 수 있어 새벽 4시를 초기화되는 시간으로 설정했습니다.
    * 이에 해당하는 테스트코드 작성

### 부탁드립니다.
@TeMlN 
"**해당 날짜에 신청된 노래가 없습니다.**" Exception을 추가해주시길 바랍니다.

# 중요
**현재 도토리 베타서비스 중**입니다.
**베타서비스 후 현재 PR을 merge** 해주시길 바랍니다.
> 혹시나 merge 시 베타서비스 중 문제가 생길 시 서버를 다시 올려야 할 상황이 생기면 곤란해집니다. 
(Schedule 등등 변경점 때문에 다른 코드들의 flow가 꼬일 수 있습니다.)