### PR TITLE
아직 변경되지 않은 Username -> MemberName 으로 변경 및 stdNum 을 stuNum 으로 통일

### DIFF
--- a/src/main/java/com/server/Dotori/model/member/Member.java
+++ b/src/main/java/com/server/Dotori/model/member/Member.java
@@ -124,12 +124,12 @@ public class Member extends BaseTimeEntity implements UserDetails {
         this.roles = roles != null ? roles : this.roles;
     }
 
-    public void updateStuNum(String stdNum) {
-        this.stuNum = stdNum != null ? stdNum : this.stuNum;
+    public void updateStuNum(String stuNum) {
+        this.stuNum = stuNum != null ? stuNum : this.stuNum;
     }
 
-    public void updateUsername(String name) {
-        this.memberName = name != null ? name : this.memberName;
+    public void updateMemberName(String memberName) {
+        this.memberName = memberName != null ? memberName : this.memberName;
     }
 
     public void updateRefreshToken(String refreshToken){

--- a/src/main/java/com/server/Dotori/model/member/controller/studentinfo/admin/AdminStuInfoController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/studentinfo/admin/AdminStuInfoController.java
@@ -89,17 +89,17 @@ public class AdminStuInfoController {
 
     /**
      * 학생 정보 변경 - 이름 변경
-     * @param memberNameUpdateDto (receiverId, username)
+     * @param memberNameUpdateDto (receiverId, memberName)
      * @return CommonResult - SuccessResult
      */
-    @PutMapping("/info/username")
+    @PutMapping("/info/membername")
     @ResponseStatus( HttpStatus.OK )
     @ApiOperation(value = "이름 변경", notes = "이름 변경")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
-    public CommonResult updateUsernameAdmin(@RequestBody MemberNameUpdateDto memberNameUpdateDto) {
+    public CommonResult updateMemberNameAdmin(@RequestBody MemberNameUpdateDto memberNameUpdateDto) {
         stuInfoService.updateMemberName(memberNameUpdateDto);
         return responseService.getSuccessResult();
     }

--- a/src/main/java/com/server/Dotori/model/member/controller/studentinfo/councillor/CouncillorStuInfoController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/studentinfo/councillor/CouncillorStuInfoController.java
@@ -89,17 +89,17 @@ public class CouncillorStuInfoController {
 
     /**
      * 학생 정보 변경 - 이름 변경
-     * @param memberNameUpdateDto (receiverId, username)
+     * @param memberNameUpdateDto (receiverId, memberName)
      * @return CommonResult - SuccessResult
      */
-    @PutMapping("/info/username")
+    @PutMapping("/info/membername")
     @ResponseStatus( HttpStatus.OK )
     @ApiOperation(value = "이름 변경", notes = "이름 변경")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
-    public CommonResult updateUsernameCouncillor(@RequestBody MemberNameUpdateDto memberNameUpdateDto) {
+    public CommonResult updateMemberNameCouncillor(@RequestBody MemberNameUpdateDto memberNameUpdateDto) {
         stuInfoService.updateMemberName(memberNameUpdateDto);
         return responseService.getSuccessResult();
     }

--- a/src/main/java/com/server/Dotori/model/member/controller/studentinfo/developer/DeveloperStuInfoController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/studentinfo/developer/DeveloperStuInfoController.java
@@ -89,17 +89,17 @@ public class DeveloperStuInfoController {
 
     /**
      * 학생 정보 변경 - 이름 변경
-     * @param memberNameUpdateDto (receiverId, username)
+     * @param memberNameUpdateDto (receiverId, memberName)
      * @return CommonResult - SuccessResult
      */
-    @PutMapping("/info/username")
+    @PutMapping("/info/membername")
     @ResponseStatus( HttpStatus.OK )
     @ApiOperation(value = "이름 변경", notes = "이름 변경")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
-    public CommonResult updateUsernameDeveloper(@RequestBody MemberNameUpdateDto memberNameUpdateDto) {
+    public CommonResult updateMemberNameDeveloper(@RequestBody MemberNameUpdateDto memberNameUpdateDto) {
         stuInfoService.updateMemberName(memberNameUpdateDto);
         return responseService.getSuccessResult();
     }

--- a/src/main/java/com/server/Dotori/model/member/service/studentinfo/StuInfoServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/studentinfo/StuInfoServiceImpl.java
@@ -104,7 +104,6 @@ public class StuInfoServiceImpl implements StuInfoService {
      * 학생의 이름을 변경시키는 서비스로직 (사감쌤, 개발자, 자치위원 사용가능)
      * @param memberNameUpdateDto (receiverId, username)
      * @exception MemberNotFoundException 해당 Id에 해당하는 유저를 찾을 수 없을 때
-     * @exception MemberAlreadyJoinThisNameException 해당 이름으로 이미 가입된 유저가 있을 때
      */
     @Override
     @Transactional
@@ -112,6 +111,6 @@ public class StuInfoServiceImpl implements StuInfoService {
         Member findMember = memberRepository.findById(memberNameUpdateDto.getReceiverId())
                 .orElseThrow(() -> new MemberNotFoundException());
 
-        findMember.updateUsername(memberNameUpdateDto.getMemberName());
+        findMember.updateMemberName(memberNameUpdateDto.getMemberName());
     }
 }

--- a/src/test/java/com/server/Dotori/model/member/MemberTest.java
+++ b/src/test/java/com/server/Dotori/model/member/MemberTest.java
@@ -29,7 +29,7 @@ public class MemberTest {
         Member saveMember = memberRepository.save(
                 Member.builder()
                         .memberName("taemin")
-                        .stdNum("2406")
+                        .stuNum("2406")
                         .password("1234")
                         .email("s20014@gsm.hs.kr")
                         .roles(Collections.singletonList(Role.ROLE_ADMIN))
@@ -41,7 +41,7 @@ public class MemberTest {
 
 
         // Then
-        Assertions.assertThat(saveMember.getUsername()).isEqualTo("taemin");
+        Assertions.assertThat(saveMember.getMemberName()).isEqualTo("taemin");
 
     }
 

--- a/src/test/java/com/server/Dotori/model/member/service/MemberServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/member/service/MemberServiceTest.java
@@ -6,7 +6,7 @@ import com.server.Dotori.model.member.dto.MemberLoginDto;
 import com.server.Dotori.model.member.dto.MemberPasswordDto;
 import com.server.Dotori.model.member.enumType.Role;
 import com.server.Dotori.model.member.repository.member.MemberRepository;
-import com.server.Dotori.util.CurrentUserUtil;
+import com.server.Dotori.util.CurrentMemberUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,8 +43,8 @@ public class MemberServiceTest {
     void signup(){
         // given
         MemberDto memberDto = MemberDto.builder()
-                .username("관리자")
-                .stdNum("1111")
+                .memberName("관리자")
+                .stuNum("1111")
                 .password("1234")
                 .email("s20000@gsm.hs.kr")
                 .build();
@@ -59,11 +59,11 @@ public class MemberServiceTest {
 
     @BeforeEach
     @DisplayName("로그인 되어있는 유저를 확인하는 테스트")
-    void currentUser() {
+    void currentMember() {
         //given
         MemberDto memberDto = MemberDto.builder()
-                .username("노경준")
-                .stdNum("2206")
+                .memberName("노경준")
+                .stuNum("2206")
                 .password("1234")
                 .email("s20018@gsm.hs.kr")
                 .build();
@@ -73,7 +73,7 @@ public class MemberServiceTest {
 
         // when login session 발급
         UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
-                memberDto.getUsername(),
+                memberDto.getEmail(),
                 memberDto.getPassword(),
                 List.of(new SimpleGrantedAuthority(Role.ROLE_ADMIN.name())));
         SecurityContext context = SecurityContextHolder.getContext();
@@ -82,8 +82,8 @@ public class MemberServiceTest {
         System.out.println(context);
 
         //then
-        String currentUsername = CurrentUserUtil.getCurrentUserNickname();
-        assertEquals("노경준", currentUsername);
+        String currentEmail = CurrentMemberUtil.getCurrentEmail();
+        assertEquals("s20018@gsm.hs.kr", currentEmail);
     }
 
     @Test
@@ -100,7 +100,7 @@ public class MemberServiceTest {
 
         // then
         assertNotNull(result);
-        assertThat(result.get("username")).isEqualTo(memberRepository.findByEmail(memberLoginDto.getEmail()).orElseThrow().getUsername());
+        assertThat(result.get("email")).isEqualTo(memberRepository.findByEmail(memberLoginDto.getEmail()).orElseThrow().getEmail());
     }
 
     @Test

--- a/src/test/java/com/server/Dotori/model/member/service/studentinfo/StuInfoServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/member/service/studentinfo/StuInfoServiceTest.java
@@ -113,7 +113,7 @@ class StuInfoServiceTest {
 
     @Test
     @DisplayName("이름이 잘 변경되나요?")
-    public void updateUsernameTest() {
+    public void updateMemberNameTest() {
         //given //when
         stuInfoService.updateMemberName(
                 MemberNameUpdateDto.builder()

--- a/src/test/java/com/server/Dotori/security/SecurityTest.java
+++ b/src/test/java/com/server/Dotori/security/SecurityTest.java
@@ -17,16 +17,16 @@ public class SecurityTest {
     @Test
     public void tokenTest() {
         MemberDto memberDto = new MemberDto();
-        memberDto.setUsername("노경준");
+        memberDto.setMemberName("노경준");
         memberDto.setStuNum("2206");
         memberDto.setPassword("1234");
-        memberDto.setEmail("shrudwns@naver.com");
+        memberDto.setEmail("s20018@gsm.hs.kr");
 
-        String accessToken = jwtTokenProvider.createToken(memberDto.getUsername(), memberDto.toEntity().getRoles());
+        String accessToken = jwtTokenProvider.createToken(memberDto.getEmail(), memberDto.toEntity().getRoles());
         // 유효한 토큰인지 확인
         if (accessToken != null && jwtTokenProvider.validateToken(accessToken)){
-            String nickname = jwtTokenProvider.getUsername(accessToken);
-            Assertions.assertThat(nickname).isEqualTo("노경준");
+            String email = jwtTokenProvider.getEmail(accessToken);
+            Assertions.assertThat(email).isEqualTo("s20018@gsm.hs.kr");
         }
     }
 }


### PR DESCRIPTION
### 제가 한 일은요!
- 아직 변경되지 않은 Username -> MemberName 으로 변경 하였습니다. ( 이제 더 이상 없는 것 같습니다. )
- stdNum 변수 이름을 stuNum 으로 통일 시켰습니다. ( 이것 또한 더 이상 없는 것 같습니다. )
- 오랜만에 보는 Build Success 입니다!!
> 결과
<img width="611" alt="2022-01-13_19-40-06" src="https://user-images.githubusercontent.com/68670670/149314986-143bae98-8494-4a57-a099-aeb6c619463a.png">

### 이 PR 이 Merge가 되고 나면...
- API 명세서를 고쳐야합니다. ( Member의 이름을 바꾸는 컨트롤러의 URL이 아직도 username 으로 되어있어, 
membername으로 변경 하였습니다. 이에따라 API 명세서를 고쳐야합니다. 또한 프론트에게도 공지해야합니다. )
> 해당 부분
<img width="1334" alt="2022-01-13_19-39-40" src="https://user-images.githubusercontent.com/68670670/149314922-66e4dcaf-44ae-4f11-a3ff-0a3f85e0045d.png">

- 전 API 가 잘 동작하는지 확인 해야합니다. 