### PR TITLE
자신이 신청한 기상음악을 삭제할 수 있다. (member 권한)

### DIFF
--- a/src/main/java/com/server/Dotori/model/music/controller/member/MemberMusicController.java
+++ b/src/main/java/com/server/Dotori/model/music/controller/member/MemberMusicController.java
@@ -96,4 +96,21 @@ public class MemberMusicController {
     public SingleResult<List<MusicResDto>> findDateMusicMember(@RequestBody DateMusicDto dateMusicDto) {
         return responseService.getSingleResult(musicService.getDateMusic(dateMusicDto.getDate()));
     }
+
+    /**
+     * 음악신청 목록 개별 삭제 컨트롤러
+     * @param id id
+     * @return CommonResult - SuccessResult
+     */
+    @DeleteMapping("/music/{id}")
+    @ResponseStatus (HttpStatus.OK )
+    @ApiOperation(value = "음악 신청목록 개별 삭제", notes = "음악 신청목록 개별 삭제")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
+    public CommonResult deleteMusicAdmin(@PathVariable("id") Long id) {
+        musicService.deleteMusic(id);
+        return responseService.getSuccessResult();
+    }
 }

--- a/src/main/java/com/server/Dotori/model/music/dto/MusicResDto.java
+++ b/src/main/java/com/server/Dotori/model/music/dto/MusicResDto.java
@@ -15,6 +15,7 @@ public class MusicResDto {
     private Long id;
     private String url;
     private String memberName;
+    private String email;
 
     @CreatedDate
     private LocalDateTime createdDate;

--- a/src/main/java/com/server/Dotori/model/music/repository/MusicRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/model/music/repository/MusicRepositoryImpl.java
@@ -44,7 +44,7 @@ public class MusicRepositoryImpl implements MusicRepositoryCustom {
 
     /**
      * 신청된 음악을 조회하는 query
-     * @return List-MusicResDto (id, musicUrl, member.username)
+     * @return List-MusicResDto (id, musicUrl, member.username, member.email)
      * @author 배태현
      */
     @Override
@@ -54,6 +54,7 @@ public class MusicRepositoryImpl implements MusicRepositoryCustom {
                         music.id,
                         music.url,
                         music.member.memberName,
+                        music.member.email,
                         music.createdDate
                         ))
                 .from(music)
@@ -64,7 +65,7 @@ public class MusicRepositoryImpl implements MusicRepositoryCustom {
     /**
      * 오늘 신청된 음악을 조회하는 query
      * @param localDate localDate
-     * @return List-MusicResDto (id, musicUrl, member.username)
+     * @return List-MusicResDto (id, musicUrl, member.username, member.email)
      * @author 배태현
      */
     @Override
@@ -74,6 +75,7 @@ public class MusicRepositoryImpl implements MusicRepositoryCustom {
                         music.id,
                         music.url,
                         music.member.memberName,
+                        music.member.email,
                         music.createdDate
                         ))
                 .from(music)
@@ -88,7 +90,7 @@ public class MusicRepositoryImpl implements MusicRepositoryCustom {
     /**
      * 해당하는 날짜에 신청된 음악을 조회하는 query
      * @param date date
-     * @return List-MusicResDto (id, musicUrl, member.username)
+     * @return List-MusicResDto (id, musicUrl, member.username, member.email)
      * @author 배태현
      */
     @Override
@@ -98,6 +100,7 @@ public class MusicRepositoryImpl implements MusicRepositoryCustom {
                         music.id,
                         music.url,
                         music.member.memberName,
+                        music.member.email,
                         music.createdDate
                 ))
                 .from(music)

--- a/src/main/java/com/server/Dotori/model/music/service/MusicServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/music/service/MusicServiceImpl.java
@@ -92,16 +92,18 @@ public class MusicServiceImpl implements MusicService {
      * @author 배태현
      */
     @Override
+    @Transactional
     public void deleteMusic(Long musicId) {
         Music music = musicRepository.findById(musicId)
                 .orElseThrow(() -> new MusicNotFoundException());
 
         musicRepository.deleteById(music.getId());
+        music.getMember().updateMusic(CAN);
     }
 
     /**
      * 날짜별로 신청된 음악을 조회하는 서비스 로직 (로그인 된 유저 사용가능)
-     * @param date date (2022-01-05)
+     * @param date date (2022-01-05 같은 형식)
      * @return
      */
     @Override


### PR DESCRIPTION
### 제가 한 일이에요 !
* member 권한이 자신이 신청한 기상음악을 삭제할 수 있도록 음악을 삭제하는 controller 추가
* 프론트에서 자신이 신청한 음악인지 판단할 수 있도록 기상음악 목록에 email 추가로 반환
* 기상음악을 삭제하거나 삭제 당했을 시 삭제당한 사람이 음악신청을 다시 할 수 있도록 자습신청 상태 update

> member를 제외한 다른 권한은 모든 음악 삭제 가능
현재 그렇게 되어있습니다. 다 알고계실거에요.

### 음악신청 목록 조회 시 결과값
> 클라이언트 단에서 자신이 신청한 음악인지 식별할 수 있도록 이메일을 추가로 반환해줌

![스크린샷 2022-01-19 오후 3 51 14](https://user-images.githubusercontent.com/69895394/150079177-5fdd7c57-4759-4929-a39c-d056063cabd4.png)

### 제가 생각한 자신이 신청한 기상음악 삭제 flow입니다.
클라이언트에서 **jwt를 decode**하여 
**payload에서 email을 가져온 뒤** 
**음악신청 목록에서 email이 같은 음악을 삭제**할 수 있게한다. (**email이 같은 음악에만 삭제버튼 생성**)

클라이언트에서 jwt를 decode하여 
payload에서 email을 가져온 뒤 
**cookie나 localStorage에 저장하지 않습니다.**
**cookie나 localStorage가 변질될 시 다른사람이 신청한 음악을 삭제할 수 있을 것** 입니다.

**클라이언트는 음악목록을 조회할 때 마다 토큰(jwt)을 decode하여 자신이 신청한 음악을 판별**해야합니다. (보안성)