### PR TITLE
음악 날짜조회 cross join 명시적 join으로 변경하여 성능 개선

### DIFF
--- a/src/main/java/com/server/Dotori/model/music/repository/MusicRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/model/music/repository/MusicRepositoryImpl.java
@@ -104,6 +104,7 @@ public class MusicRepositoryImpl implements MusicRepositoryCustom {
                         music.createdDate
                 ))
                 .from(music)
+                .innerJoin(music.member, member)
                 .where(music.createdDate.stringValue().like(date+"%"))
                 .orderBy(music.createdDate.asc())
                 .fetch();


### PR DESCRIPTION
### 제가 한 일이에요 !
> cross join이란 집합에서 나올 수 있는 모든 경우를 말합니다. (당연히 일반적인 join보다 성능상 이슈가 발생하게 됩니다.)
JPA에선` @OneToOne` 관계에서 Join 쿼리 작성시 주의하지 않으면 cross join이 발생합니다.

원래의 쿼리는 별도로 join절을 선언하지 않아 corss join이 일어나며 조회가 되는 방식이였습니다.
> Hibernate의 경우 암묵적인 조인은 cross Join을 사용합니다.

암묵적 조인을 명시적 조인 inner join을 사용하여 cross join 발생문제를 해결하였습니다.
**조회 건수가 많아질수록 두 쿼리의 수행시간은 차이나게 될겁니다 !**

> 이 쿼리 외에도 제 작업영역에서 cross join이 발생하는 부분을 발견하면 슬랙에 올려주세요 

### cross join이 발생하던 쿼리
<img width="800" alt="스크린샷 2022-01-19 오후 9 12 29" src="https://user-images.githubusercontent.com/69895394/150127165-5b372ff4-a978-4197-9117-5ece32a34efe.png">

### inner join으로 변경된 쿼리
<img width="722" alt="스크린샷 2022-01-19 오후 8 48 22" src="https://user-images.githubusercontent.com/69895394/150127190-9c96f232-22c4-4d07-b87c-6af6800f8069.png">

