### PR TITLE
자습신청 금지 학생 일주일 뒤에 자동으로 금지 해제

### DIFF
--- a/src/main/java/com/server/Dotori/model/member/repository/member/MemberRepositoryCustom.java
+++ b/src/main/java/com/server/Dotori/model/member/repository/member/MemberRepositoryCustom.java
@@ -21,4 +21,6 @@ public interface MemberRepositoryCustom {
     List<Member> findStudentInfo(Long id);
 
     List<Member> findAllStudentInfo();
+
+    void updateUnBanSelfStudy();
 }

--- a/src/main/java/com/server/Dotori/model/member/repository/member/MemberRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/repository/member/MemberRepositoryImpl.java
@@ -144,13 +144,18 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .fetch();
     }
 
+    /**
+     * 자습신청 금지 상태이며 자습신청 만료기간이 다 된 학생 <br>
+     * 자습신청 금지를 해제하고 자습신청 만료기간을 초기화하는 쿼리
+     * @author 배태현
+     */
     @Override
     public void updateUnBanSelfStudy() {
         queryFactory
                 .update(member)
                 .where(
                         member.selfStudy.eq(SelfStudy.IMPOSSIBLE)
-                        .and(member.selfStudyExpiredDate.stringValue().substring(0,10).eq(String.valueOf(LocalDate.now().plusDays(7))))
+                        .and(member.selfStudyExpiredDate.stringValue().substring(0,10).eq(String.valueOf(LocalDate.now())))
                 )
                 .set(member.selfStudy, SelfStudy.CAN)
                 .set(member.selfStudyExpiredDate, (LocalDateTime) null)

--- a/src/main/java/com/server/Dotori/model/member/repository/member/MemberRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/repository/member/MemberRepositoryImpl.java
@@ -8,6 +8,7 @@ import com.server.Dotori.model.member.dto.SelfStudyStudentsDto;
 import com.server.Dotori.model.member.enumType.SelfStudy;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -141,5 +142,18 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .select(member)
                 .orderBy(member.stuNum.asc())
                 .fetch();
+    }
+
+    @Override
+    public void updateUnBanSelfStudy() {
+        queryFactory
+                .update(member)
+                .where(
+                        member.selfStudy.eq(SelfStudy.IMPOSSIBLE)
+                        .and(member.selfStudyExpiredDate.stringValue().substring(0,10).eq(String.valueOf(LocalDate.now().plusDays(7))))
+                )
+                .set(member.selfStudy, SelfStudy.CAN)
+                .set(member.selfStudyExpiredDate, (LocalDateTime) null)
+                .execute();
     }
 }

--- a/src/main/java/com/server/Dotori/model/member/schedule/SelfStudySchedule.java
+++ b/src/main/java/com/server/Dotori/model/member/schedule/SelfStudySchedule.java
@@ -16,7 +16,7 @@ public class SelfStudySchedule {
     private final SelfStudyService selfStudyService;
 
     /**
-     * "월 ~ 금 새벽 2시"에 학생들 자습신청 상태를 자동으로 변경해주는 Schedule
+     * "월 ~ 금 새벽 2시"에 학생들 자습신청 상태(금지, 신청함, 신청취소)를 자동으로 변경해주고 자습신청 카운트를 초기화 시키는 Schedule
      * @author 배태현
      */
     @Scheduled(cron = "0 0 2 ? * MON-FRI")

--- a/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
@@ -164,7 +164,7 @@ public class SelfStudyServiceImpl implements SelfStudyService {
                 .orElseThrow(MemberNotFoundException::new);
 
         findMember.updateSelfStudy(IMPOSSIBLE);
-        findMember.updateSelfStudyExpiredDate(LocalDateTime.now().plusDays(7));
+        findMember.updateSelfStudyExpiredDate(LocalDateTime.now());
     }
 
     /**

--- a/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
@@ -164,7 +164,7 @@ public class SelfStudyServiceImpl implements SelfStudyService {
                 .orElseThrow(MemberNotFoundException::new);
 
         findMember.updateSelfStudy(IMPOSSIBLE);
-        findMember.updateSelfStudyExpiredDate(LocalDateTime.now());
+        findMember.updateSelfStudyExpiredDate(LocalDateTime.now().plusDays(7));
     }
 
     /**

--- a/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/selfstudy/SelfStudyServiceImpl.java
@@ -128,7 +128,7 @@ public class SelfStudyServiceImpl implements SelfStudyService {
     }
 
     /**
-     * 자습신청 상태를 '신청가능'으로 변경하고, 자습신청 카운트 초기화 서비스로직 (Schedule)
+     * 자습신청 상태를 '신청가능'으로 변경하고, 자습신청 카운트 초기화, 자습신청 금지 만료기간이 되었다면 다시 신청할 수 있는 상태로 변경해주는 서비스로직 (Schedule)
      * @author 배태현
      */
     @Override
@@ -136,6 +136,7 @@ public class SelfStudyServiceImpl implements SelfStudyService {
     public void updateSelfStudyStatus() {
         selfStudyRepository.deleteAll();
         memberRepository.updateSelfStudyStatus();
+        memberRepository.updateUnBanSelfStudy();
     }
 
     /**


### PR DESCRIPTION
### 제가 한 일이에요 !
* 자습신청 금지 해제해주는 쿼리 작성
* 자습신청 스케줄러에 금지 해제해주는 로직 추가

> 월 ~ 금 새벽 2시에 체크하게 되며 만료기간이 다 되면 자동으로 자습신청 가능 상태로 변경됩니다.
월 ~ 금요일 중 자습신청 금지를 당하므로 월 ~ 금요일에 실행되는 스케줄러에 추가했습니다. (자습신청 금지기간은 7일)