### PR TITLE
단일 학생 규정위반 정보 단일 조회 기능 개발

### DIFF
--- a/src/main/java/com/server/Dotori/model/rule/controller/RuleController.java
+++ b/src/main/java/com/server/Dotori/model/rule/controller/RuleController.java
@@ -35,8 +35,16 @@ public class RuleController {
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = false, dataType = "String", paramType = "header"),
     })
     @GetMapping("/all/{stuNum}")
-    public SingleResult<HashMap<Rule, RulesCntAndDatesDto>> findAllViolationOfTheRules(@PathVariable("stuNum") String stuNum){
-        return responseService.getSingleResult(ruleService.findAllViolationOfTheRules(stuNum));
+    public SingleResult<HashMap<Rule, RulesCntAndDatesDto>> findAllViolationOfTheRule(@PathVariable("stuNum") String stuNum){
+        return responseService.getSingleResult(ruleService.findAllViolationOfTheRule(stuNum));
+    }
+
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = false, dataType = "String", paramType = "header"),
+    })
+    @GetMapping("/{stuNum}")
+    public CommonResult findViolationOfTheRules(@PathVariable("stuNum") String stuNum){
+        return responseService.getSingleResult(ruleService.findViolationOfTheRules(stuNum));
     }
 
 }

--- a/src/main/java/com/server/Dotori/model/rule/dto/FindIdAndRuleAndDateDto.java
+++ b/src/main/java/com/server/Dotori/model/rule/dto/FindIdAndRuleAndDateDto.java
@@ -1,0 +1,16 @@
+package com.server.Dotori.model.rule.dto;
+
+import com.server.Dotori.model.rule.enumType.Rule;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Getter
+public class FindIdAndRuleAndDateDto {
+
+    private Long Id;
+    private Rule rule;
+    private LocalDateTime createdDate;
+}

--- a/src/main/java/com/server/Dotori/model/rule/dto/FindRuleAndDateDto.java
+++ b/src/main/java/com/server/Dotori/model/rule/dto/FindRuleAndDateDto.java
@@ -1,16 +1,14 @@
 package com.server.Dotori.model.rule.dto;
 
 import com.server.Dotori.model.rule.enumType.Rule;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @AllArgsConstructor
 @Getter
-public class FindRulesAndDatesDto {
+public class FindRuleAndDateDto {
 
     private Rule rules;
     private LocalDateTime dates;

--- a/src/main/java/com/server/Dotori/model/rule/dto/FindViolationOfTheRuleResponseDto.java
+++ b/src/main/java/com/server/Dotori/model/rule/dto/FindViolationOfTheRuleResponseDto.java
@@ -1,0 +1,17 @@
+package com.server.Dotori.model.rule.dto;
+
+import com.server.Dotori.model.rule.enumType.Rule;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class FindViolationOfTheRuleResponseDto {
+    private Long id;
+    private Rule rule;
+    private String createdDate;
+}

--- a/src/main/java/com/server/Dotori/model/rule/repository/RuleRepositoryCustom.java
+++ b/src/main/java/com/server/Dotori/model/rule/repository/RuleRepositoryCustom.java
@@ -1,9 +1,12 @@
 package com.server.Dotori.model.rule.repository;
 
-import com.server.Dotori.model.rule.dto.FindRulesAndDatesDto;
+import com.server.Dotori.model.rule.dto.FindIdAndRuleAndDateDto;
+import com.server.Dotori.model.rule.dto.FindRuleAndDateDto;
 
 import java.util.List;
 
 public interface RuleRepositoryCustom {
-    List<FindRulesAndDatesDto> findViolationOfTheRules(String stuNum);
+    List<FindRuleAndDateDto> findViolationOfTheRule(String stuNum);
+
+    List<FindIdAndRuleAndDateDto> findViolationOfTheRules(String stuNum);
 }

--- a/src/main/java/com/server/Dotori/model/rule/repository/RuleRepositoryCustomImpl.java
+++ b/src/main/java/com/server/Dotori/model/rule/repository/RuleRepositoryCustomImpl.java
@@ -47,6 +47,7 @@ public class RuleRepositoryCustomImpl implements RuleRepositoryCustom{
                 .from(ruleViolation)
                 .innerJoin(ruleViolation.member, member)
                 .where(ruleViolation.member.stuNum.eq(stuNum))
+                .orderBy(ruleViolation.createdDate.desc())
                 .fetch();
 
         return result;

--- a/src/main/java/com/server/Dotori/model/rule/repository/RuleRepositoryCustomImpl.java
+++ b/src/main/java/com/server/Dotori/model/rule/repository/RuleRepositoryCustomImpl.java
@@ -2,7 +2,8 @@ package com.server.Dotori.model.rule.repository;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.server.Dotori.model.rule.dto.FindRulesAndDatesDto;
+import com.server.Dotori.model.rule.dto.FindIdAndRuleAndDateDto;
+import com.server.Dotori.model.rule.dto.FindRuleAndDateDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -23,9 +24,24 @@ public class RuleRepositoryCustomImpl implements RuleRepositoryCustom{
      * @return result - List<FindRulesAndDatesDto> - rules, date
      */
     @Override
-    public List<FindRulesAndDatesDto> findViolationOfTheRules(String stuNum) {
-        List<FindRulesAndDatesDto> result = queryFactory
-                .select(Projections.constructor(FindRulesAndDatesDto.class,
+    public List<FindRuleAndDateDto> findViolationOfTheRule(String stuNum) {
+        List<FindRuleAndDateDto> result = queryFactory
+                .select(Projections.constructor(FindRuleAndDateDto.class,
+                        ruleViolation.rule,
+                        ruleViolation.createdDate))
+                .from(ruleViolation)
+                .innerJoin(ruleViolation.member, member)
+                .where(ruleViolation.member.stuNum.eq(stuNum))
+                .fetch();
+
+        return result;
+    }
+
+    @Override
+    public List<FindIdAndRuleAndDateDto> findViolationOfTheRules(String stuNum) {
+        List<FindIdAndRuleAndDateDto> result = queryFactory
+                .select(Projections.constructor(FindIdAndRuleAndDateDto.class,
+                        ruleViolation.id,
                         ruleViolation.rule,
                         ruleViolation.createdDate))
                 .from(ruleViolation)

--- a/src/main/java/com/server/Dotori/model/rule/service/RuleService.java
+++ b/src/main/java/com/server/Dotori/model/rule/service/RuleService.java
@@ -1,6 +1,6 @@
 package com.server.Dotori.model.rule.service;
 
-import com.server.Dotori.model.rule.dto.FindIdAndRuleAndDateDto;
+import com.server.Dotori.model.rule.dto.FindViolationOfTheRuleResponseDto;
 import com.server.Dotori.model.rule.dto.RuleGrantDto;
 import com.server.Dotori.model.rule.dto.RulesCntAndDatesDto;
 import com.server.Dotori.model.rule.enumType.Rule;
@@ -11,5 +11,5 @@ import java.util.List;
 public interface RuleService {
     void grant(RuleGrantDto ruleGrantDto);
     HashMap<Rule, RulesCntAndDatesDto> findAllViolationOfTheRule(String stuNum);
-    List<FindIdAndRuleAndDateDto> findViolationOfTheRules(String stuNum);
+    List<FindViolationOfTheRuleResponseDto> findViolationOfTheRules(String stuNum);
 }

--- a/src/main/java/com/server/Dotori/model/rule/service/RuleService.java
+++ b/src/main/java/com/server/Dotori/model/rule/service/RuleService.java
@@ -1,12 +1,15 @@
 package com.server.Dotori.model.rule.service;
 
+import com.server.Dotori.model.rule.dto.FindIdAndRuleAndDateDto;
 import com.server.Dotori.model.rule.dto.RuleGrantDto;
 import com.server.Dotori.model.rule.dto.RulesCntAndDatesDto;
 import com.server.Dotori.model.rule.enumType.Rule;
 
 import java.util.HashMap;
+import java.util.List;
 
 public interface RuleService {
     void grant(RuleGrantDto ruleGrantDto);
-    HashMap<Rule, RulesCntAndDatesDto> findAllViolationOfTheRules(String stuNum);
+    HashMap<Rule, RulesCntAndDatesDto> findAllViolationOfTheRule(String stuNum);
+    List<FindIdAndRuleAndDateDto> findViolationOfTheRules(String stuNum);
 }

--- a/src/main/java/com/server/Dotori/model/rule/service/RuleServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/rule/service/RuleServiceImpl.java
@@ -4,7 +4,8 @@ import com.server.Dotori.exception.member.exception.MemberNotFoundException;
 import com.server.Dotori.model.member.Member;
 import com.server.Dotori.model.member.repository.member.MemberRepository;
 import com.server.Dotori.model.rule.RuleViolation;
-import com.server.Dotori.model.rule.dto.FindRulesAndDatesDto;
+import com.server.Dotori.model.rule.dto.FindIdAndRuleAndDateDto;
+import com.server.Dotori.model.rule.dto.FindRuleAndDateDto;
 import com.server.Dotori.model.rule.dto.RuleGrantDto;
 import com.server.Dotori.model.rule.dto.RulesCntAndDatesDto;
 import com.server.Dotori.model.rule.enumType.Rule;
@@ -36,9 +37,9 @@ public class RuleServiceImpl implements RuleService{
     }
 
     @Override
-    public HashMap<Rule, RulesCntAndDatesDto> findAllViolationOfTheRules(String stuNum) {
-        HashMap<Rule, RulesCntAndDatesDto> result = new LinkedHashMap<>();
-        List<FindRulesAndDatesDto> findRulesAndDatesDto = ruleRepository.findViolationOfTheRules(stuNum);
+    public HashMap<Rule, RulesCntAndDatesDto> findAllViolationOfTheRule(String stuNum) {
+        HashMap<Rule, RulesCntAndDatesDto> response = new LinkedHashMap<>();
+        List<FindRuleAndDateDto> findRulesAndDatesDto = ruleRepository.findViolationOfTheRule(stuNum);
 
         int cnt = 0;
         for (Rule rule : Rule.values()) {
@@ -50,11 +51,18 @@ public class RuleServiceImpl implements RuleService{
                 }
             }
             RulesCntAndDatesDto rulesCntAndDatesDto = new RulesCntAndDatesDto(cnt, localDateTime);
-            result.put(rule,rulesCntAndDatesDto);
+            response.put(rule,rulesCntAndDatesDto);
             cnt = 0;
         }
 
-        return result;
+        return response;
+    }
+
+    @Override
+    public List<FindIdAndRuleAndDateDto> findViolationOfTheRules(String stuNum) {
+        List<FindIdAndRuleAndDateDto> response = ruleRepository.findViolationOfTheRules(stuNum);
+
+        return response;
     }
 
 }

--- a/src/main/java/com/server/Dotori/model/rule/service/RuleServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/rule/service/RuleServiceImpl.java
@@ -4,10 +4,7 @@ import com.server.Dotori.exception.member.exception.MemberNotFoundException;
 import com.server.Dotori.model.member.Member;
 import com.server.Dotori.model.member.repository.member.MemberRepository;
 import com.server.Dotori.model.rule.RuleViolation;
-import com.server.Dotori.model.rule.dto.FindIdAndRuleAndDateDto;
-import com.server.Dotori.model.rule.dto.FindRuleAndDateDto;
-import com.server.Dotori.model.rule.dto.RuleGrantDto;
-import com.server.Dotori.model.rule.dto.RulesCntAndDatesDto;
+import com.server.Dotori.model.rule.dto.*;
 import com.server.Dotori.model.rule.enumType.Rule;
 import com.server.Dotori.model.rule.repository.RuleRepository;
 import lombok.RequiredArgsConstructor;
@@ -38,13 +35,15 @@ public class RuleServiceImpl implements RuleService{
 
     @Override
     public HashMap<Rule, RulesCntAndDatesDto> findAllViolationOfTheRule(String stuNum) {
+        if(!memberRepository.existsByStuNum(stuNum)) throw new MemberNotFoundException();
+
         HashMap<Rule, RulesCntAndDatesDto> response = new LinkedHashMap<>();
         List<FindRuleAndDateDto> findRulesAndDatesDto = ruleRepository.findViolationOfTheRule(stuNum);
 
         int cnt = 0;
         for (Rule rule : Rule.values()) {
             List<String> localDateTime = new LinkedList<>();
-            for (int i = 0; i < findRulesAndDatesDto.size(); i++) { // 3
+            for (int i = 0; i < findRulesAndDatesDto.size(); i++) {
                 if(findRulesAndDatesDto.get(i).getRules().equals(rule)){
                     localDateTime.add(findRulesAndDatesDto.get(i).getDates().toString().substring(0,10));
                     cnt++;
@@ -59,8 +58,21 @@ public class RuleServiceImpl implements RuleService{
     }
 
     @Override
-    public List<FindIdAndRuleAndDateDto> findViolationOfTheRules(String stuNum) {
-        List<FindIdAndRuleAndDateDto> response = ruleRepository.findViolationOfTheRules(stuNum);
+    public List<FindViolationOfTheRuleResponseDto> findViolationOfTheRules(String stuNum) {
+        if(!memberRepository.existsByStuNum(stuNum)) throw new MemberNotFoundException();
+
+        List<FindIdAndRuleAndDateDto> result = ruleRepository.findViolationOfTheRules(stuNum);
+        List<FindViolationOfTheRuleResponseDto> response = new LinkedList<>();
+
+        for (FindIdAndRuleAndDateDto dto : result) {
+            FindViolationOfTheRuleResponseDto responseDto = FindViolationOfTheRuleResponseDto.builder()
+                    .id(dto.getId())
+                    .rule(dto.getRule())
+                    .createdDate(dto.getCreatedDate().toString().substring(0, 10))
+                    .build();
+
+            response.add(responseDto);
+        }
 
         return response;
     }

--- a/src/test/java/com/server/Dotori/model/rule/service/RuleServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/rule/service/RuleServiceTest.java
@@ -3,27 +3,21 @@ package com.server.Dotori.model.rule.service;
 import com.server.Dotori.exception.member.exception.MemberNotFoundException;
 import com.server.Dotori.model.member.dto.MemberDto;
 import com.server.Dotori.model.member.repository.member.MemberRepository;
-import com.server.Dotori.model.member.service.MemberService;
-import com.server.Dotori.model.rule.RuleViolation;
 import com.server.Dotori.model.rule.dto.RuleGrantDto;
 import com.server.Dotori.model.rule.dto.RulesCntAndDatesDto;
 import com.server.Dotori.model.rule.enumType.Rule;
 import com.server.Dotori.model.rule.repository.RuleRepository;
-import lombok.RequiredArgsConstructor;
-import org.aspectj.lang.annotation.After;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.persistence.EntityManager;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -127,7 +121,7 @@ public class RuleServiceTest {
         );
 
         // when
-        HashMap<Rule, RulesCntAndDatesDto> violationOfTheRules = ruleService.findAllViolationOfTheRules("2206");
+        HashMap<Rule, RulesCntAndDatesDto> violationOfTheRules = ruleService.findAllViolationOfTheRule("2206");
 
         // then
         assertThat(violationOfTheRules.get(Rule.FIREARMS1).getCnt()).isEqualTo(1);


### PR DESCRIPTION
### 제가 한 일은요!!
- 단일 학생 규정위반 정보 단일 조회 기능 개발을 했습니다.
- 기존의 ```단일 학생 규정위반 정보 전체 조회```,```학생 규정위반 기록하기(부여)``` 기능에서 학번의 해당하는 학생을 존재유무를 확인하는 조건문을 추가했습니다

> 결과
<img width="1411" alt="2022-01-24_13-23-59" src="https://user-images.githubusercontent.com/68670670/150721797-6c99d136-1a12-43e4-825d-1f19b4062e66.png">
.