### PR TITLE
도토리 클라이언트 개발자들정보 서버 띄워질 때 회원가입시키는 로직 추가

### DIFF
--- a/src/main/java/com/server/Dotori/dev_config/GenerateMember.java
+++ b/src/main/java/com/server/Dotori/dev_config/GenerateMember.java
@@ -41,6 +41,11 @@ public class GenerateMember {
         Member taehyeon = createTaehyeonAccount();
         Member taemin = createTaeminAccount();
         Member kyungjun = createKyungjunAccount();
+        createChanggyuAccount();
+        createTaehwanAccount();
+        createSihyeonAccount();
+        createGihongAccount();
+        createJinguAccount();
 
         loggingAccessToken(admin, developer, councillor, taehyeon, taemin, kyungjun);
     }
@@ -122,6 +127,56 @@ public class GenerateMember {
                         .memberName("노경준")
                         .stuNum("2206")
                         .email("s20018@gsm.hs.kr")
+                        .build().toEntity(passwordEncoder.encode("string"))
+        );
+    }
+
+    private void createChanggyuAccount() {
+        memberRepository.save(
+                MemberDto.builder()
+                        .memberName("임창규")
+                        .stuNum("2215")
+                        .email("s20058@gsm.hs.kr")
+                        .build().toEntity(passwordEncoder.encode("string"))
+        );
+    }
+
+    private void createTaehwanAccount() {
+        memberRepository.save(
+                MemberDto.builder()
+                        .memberName("정태환")
+                        .stuNum("2415")
+                        .email("s20069@gsm.hs.kr")
+                        .build().toEntity(passwordEncoder.encode("string"))
+        );
+    }
+
+    private void createSihyeonAccount() {
+        memberRepository.save(
+                MemberDto.builder()
+                        .memberName("송시현")
+                        .stuNum("2212")
+                        .email("s20040@gsm.hs.kr")
+                        .build().toEntity(passwordEncoder.encode("string"))
+        );
+    }
+
+    private void createGihongAccount() {
+        memberRepository.save(
+                MemberDto.builder()
+                        .memberName("김기홍")
+                        .stuNum("2301")
+                        .email("s20005@gsm.hs.kr")
+                        .build().toEntity(passwordEncoder.encode("string"))
+        );
+    }
+
+    private void createJinguAccount() {
+        memberRepository.save(
+                MemberDto.builder()
+                        .memberName("권진구")
+                        .stuNum("2402")
+                        .email("s20004@gsm.hs.kr")
                         .build().toEntity(passwordEncoder.encode("string"))
         );
     }

--- a/src/main/java/com/server/Dotori/dev_config/GenerateMember.java
+++ b/src/main/java/com/server/Dotori/dev_config/GenerateMember.java
@@ -133,51 +133,86 @@ public class GenerateMember {
 
     private void createChanggyuAccount() {
         memberRepository.save(
-                MemberDto.builder()
+                Member.builder()
+                        .id(7L)
                         .memberName("임창규")
                         .stuNum("2215")
                         .email("s20058@gsm.hs.kr")
-                        .build().toEntity(passwordEncoder.encode("string"))
+                        .password(passwordEncoder.encode("string"))
+                        .point(0L)
+                        .refreshToken(null)
+                        .roles(singletonList(ROLE_DEVELOPER))
+                        .selfStudy(SelfStudy.CAN)
+                        .music(Music.CAN)
+                        .build()
         );
     }
 
     private void createTaehwanAccount() {
         memberRepository.save(
-                MemberDto.builder()
+                Member.builder()
+                        .id(8L)
                         .memberName("정태환")
                         .stuNum("2415")
                         .email("s20069@gsm.hs.kr")
-                        .build().toEntity(passwordEncoder.encode("string"))
+                        .password(passwordEncoder.encode("string"))
+                        .point(0L)
+                        .refreshToken(null)
+                        .roles(singletonList(ROLE_DEVELOPER))
+                        .selfStudy(SelfStudy.CAN)
+                        .music(Music.CAN)
+                        .build()
         );
     }
 
     private void createSihyeonAccount() {
         memberRepository.save(
-                MemberDto.builder()
+                Member.builder()
+                        .id(9L)
                         .memberName("송시현")
                         .stuNum("2212")
                         .email("s20040@gsm.hs.kr")
-                        .build().toEntity(passwordEncoder.encode("string"))
+                        .password(passwordEncoder.encode("string"))
+                        .point(0L)
+                        .refreshToken(null)
+                        .roles(singletonList(ROLE_DEVELOPER))
+                        .selfStudy(SelfStudy.CAN)
+                        .music(Music.CAN)
+                        .build()
         );
     }
 
     private void createGihongAccount() {
         memberRepository.save(
-                MemberDto.builder()
+                Member.builder()
+                        .id(10L)
                         .memberName("김기홍")
                         .stuNum("2301")
                         .email("s20005@gsm.hs.kr")
-                        .build().toEntity(passwordEncoder.encode("string"))
+                        .password(passwordEncoder.encode("string"))
+                        .point(0L)
+                        .refreshToken(null)
+                        .roles(singletonList(ROLE_DEVELOPER))
+                        .selfStudy(SelfStudy.CAN)
+                        .music(Music.CAN)
+                        .build()
         );
     }
 
     private void createJinguAccount() {
         memberRepository.save(
-                MemberDto.builder()
+                Member.builder()
+                        .id(11L)
                         .memberName("권진구")
                         .stuNum("2402")
                         .email("s20004@gsm.hs.kr")
-                        .build().toEntity(passwordEncoder.encode("string"))
+                        .password(passwordEncoder.encode("string"))
+                        .point(0L)
+                        .refreshToken(null)
+                        .roles(singletonList(ROLE_DEVELOPER))
+                        .selfStudy(SelfStudy.CAN)
+                        .music(Music.CAN)
+                        .build()
         );
     }
 


### PR DESCRIPTION
### 제가 한 일이에요 !
* 개발용 서버에 새로 배포했을 때 클라이언트 개발자들이 새로 로그인해야하는 번거로움이 있었으므로 
서버 띄울 때 클라이언트 개발자들 정보로 회원가입 시키는 로직을 추가했습니다.

> 서버 로그에 클라이언트 개발자들 정보로 만들어진 토큰은 뜨지 않게 했습니다. (원래 뜨던대로 뜬다는 얘기입니다.)

<img width="1917" alt="스크린샷 2022-01-25 오후 9 42 20" src="https://user-images.githubusercontent.com/69895394/150978908-649491d0-7e28-49f3-b86f-14ed99d9d50e.png">

![스크린샷 2022-01-25 오후 9 39 22](https://user-images.githubusercontent.com/69895394/150978499-5a94538d-6616-4b29-b015-fe9a64565e87.png)