### PR TITLE
안마의자 신청 취소 로직 추가

### DIFF
--- a/src/main/java/com/server/Dotori/exception/massage/MassageExceptionHandler.java
+++ b/src/main/java/com/server/Dotori/exception/massage/MassageExceptionHandler.java
@@ -1,9 +1,6 @@
 package com.server.Dotori.exception.massage;
 
-import com.server.Dotori.exception.massage.exception.MassageAlreadyException;
-import com.server.Dotori.exception.massage.exception.MassageCantRequestDateException;
-import com.server.Dotori.exception.massage.exception.MassageCantRequestTimeException;
-import com.server.Dotori.exception.massage.exception.MassageOverException;
+import com.server.Dotori.exception.massage.exception.*;
 import com.server.Dotori.response.result.CommonResult;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -15,6 +12,7 @@ public interface MassageExceptionHandler {
     String MASSAGE_OVER = "massage-over";
     String MASSAGE_CANT_REQUEST_DATE = "massage-cant-request-date";
     String MASSAGE_CANT_REQUEST_TIME = "massage-cant-request-time";
+    String MASSAGE_NOT_APPLIED_STATUS = "massage-not-applied-status";
 
     @ExceptionHandler(MassageAlreadyException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
@@ -31,4 +29,8 @@ public interface MassageExceptionHandler {
     @ExceptionHandler(MassageCantRequestTimeException.class)
     @ResponseStatus(HttpStatus.ACCEPTED)
     CommonResult massageCantRequestTimeException(MassageCantRequestTimeException ex);
+
+    @ExceptionHandler(MassageNotAppliedStatusException.class)
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    CommonResult massageNotAppliedStatusException(MassageNotAppliedStatusException ex);
 }

--- a/src/main/java/com/server/Dotori/exception/massage/MassageExceptionHandlerImpl.java
+++ b/src/main/java/com/server/Dotori/exception/massage/MassageExceptionHandlerImpl.java
@@ -1,9 +1,6 @@
 package com.server.Dotori.exception.massage;
 
-import com.server.Dotori.exception.massage.exception.MassageAlreadyException;
-import com.server.Dotori.exception.massage.exception.MassageCantRequestDateException;
-import com.server.Dotori.exception.massage.exception.MassageCantRequestTimeException;
-import com.server.Dotori.exception.massage.exception.MassageOverException;
+import com.server.Dotori.exception.massage.exception.*;
 import com.server.Dotori.response.result.CommonResult;
 import com.server.Dotori.util.ExceptionResponseObjectUtil;
 import lombok.RequiredArgsConstructor;
@@ -42,5 +39,11 @@ public class MassageExceptionHandlerImpl implements MassageExceptionHandler {
     public CommonResult massageCantRequestTimeException(MassageCantRequestTimeException ex) {
         log.debug("=== Massage Cant Request Time Exception 발생 ===");
         return exceptionResponseObjectUtil.getExceptionResponseObject(MASSAGE_CANT_REQUEST_TIME);
+    }
+
+    @Override
+    public CommonResult massageNotAppliedStatusException(MassageNotAppliedStatusException ex) {
+        log.debug("=== Massage Not Applied Status Exception 발생 ===");
+        return exceptionResponseObjectUtil.getExceptionResponseObject(MASSAGE_NOT_APPLIED_STATUS);
     }
 }

--- a/src/main/java/com/server/Dotori/exception/massage/controller/MassageExceptionController.java
+++ b/src/main/java/com/server/Dotori/exception/massage/controller/MassageExceptionController.java
@@ -1,0 +1,2 @@
+package com.server.Dotori.exception.massage.controller;public class MassageExceptionController {
+}

--- a/src/main/java/com/server/Dotori/exception/massage/controller/MassageExceptionController.java
+++ b/src/main/java/com/server/Dotori/exception/massage/controller/MassageExceptionController.java
@@ -1,2 +1,38 @@
-package com.server.Dotori.exception.massage.controller;public class MassageExceptionController {
+package com.server.Dotori.exception.massage.controller;
+
+import com.server.Dotori.exception.massage.exception.*;
+import com.server.Dotori.response.result.CommonResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/exception")
+public class MassageExceptionController {
+
+    @GetMapping("/massage-already")
+    public CommonResult massageAlreadyException() {
+        throw new MassageAlreadyException();
+    }
+
+    @GetMapping("/massage-over")
+    public CommonResult massageOverException() {
+        throw new MassageOverException();
+    }
+
+    @GetMapping("/massage-cant-request-date")
+    public CommonResult massageCantRequestDateException() {
+        throw new MassageCantRequestDateException();
+    }
+
+    @GetMapping("/massage-cant-request-time")
+    public CommonResult massageCantRequestTimeException() {
+        throw new MassageCantRequestTimeException();
+    }
+
+    @GetMapping("/massage-not-applied-status")
+    public CommonResult massageNotAppliedStatusException() {
+        throw new MassageNotAppliedStatusException();
+    }
+
 }

--- a/src/main/java/com/server/Dotori/exception/massage/exception/MassageNotAppliedStatusException.java
+++ b/src/main/java/com/server/Dotori/exception/massage/exception/MassageNotAppliedStatusException.java
@@ -1,0 +1,2 @@
+package com.server.Dotori.exception.massage.exception;public class MassageNotAppliedStatusException {
+}

--- a/src/main/java/com/server/Dotori/exception/massage/exception/MassageNotAppliedStatusException.java
+++ b/src/main/java/com/server/Dotori/exception/massage/exception/MassageNotAppliedStatusException.java
@@ -1,2 +1,13 @@
-package com.server.Dotori.exception.massage.exception;public class MassageNotAppliedStatusException {
+package com.server.Dotori.exception.massage.exception;
+
+public class MassageNotAppliedStatusException extends RuntimeException {
+    public MassageNotAppliedStatusException(String msg, Throwable t) {
+        super(msg, t);
+    }
+    public MassageNotAppliedStatusException(String msg) {
+        super(msg);
+    }
+    public MassageNotAppliedStatusException() {
+        super();
+    }
 }

--- a/src/main/java/com/server/Dotori/model/massage/controller/councillor/CouncillorMassageController.java
+++ b/src/main/java/com/server/Dotori/model/massage/controller/councillor/CouncillorMassageController.java
@@ -35,4 +35,17 @@ public class CouncillorMassageController {
         massageService.requestMassage(currentTime.getDayOfWeek(), currentTime.getHour(), currentTime.getMinute());
         return responseService.getSuccessResult();
     }
+
+    @PutMapping("/cancel/massage")
+    @ResponseStatus( HttpStatus.OK )
+    @ApiOperation(value = "안마의자 신청 취소", notes = "안마의자 신청 취소")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
+    public CommonResult cancelMassageCouncillor() {
+        LocalDateTime currentTime = LocalDateTime.now();
+        massageService.cancelMassage(currentTime.getDayOfWeek(), currentTime.getHour(), currentTime.getMinute());
+        return responseService.getSuccessResult();
+    }
 }

--- a/src/main/java/com/server/Dotori/model/massage/controller/developer/DeveloperMassageController.java
+++ b/src/main/java/com/server/Dotori/model/massage/controller/developer/DeveloperMassageController.java
@@ -35,4 +35,17 @@ public class DeveloperMassageController {
         massageService.requestMassage(currentTime.getDayOfWeek(), currentTime.getHour(), currentTime.getMinute());
         return responseService.getSuccessResult();
     }
+
+    @PutMapping("/cancel/massage")
+    @ResponseStatus( HttpStatus.OK )
+    @ApiOperation(value = "안마의자 신청 취소", notes = "안마의자 신청 취소")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
+    public CommonResult cancelMassageDeveloper() {
+        LocalDateTime currentTime = LocalDateTime.now();
+        massageService.cancelMassage(currentTime.getDayOfWeek(), currentTime.getHour(), currentTime.getMinute());
+        return responseService.getSuccessResult();
+    }
 }

--- a/src/main/java/com/server/Dotori/model/massage/controller/member/MemberMassageController.java
+++ b/src/main/java/com/server/Dotori/model/massage/controller/member/MemberMassageController.java
@@ -36,4 +36,17 @@ public class MemberMassageController {
         return responseService.getSuccessResult();
     }
 
+    @PutMapping("/cancel/massage")
+    @ResponseStatus( HttpStatus.OK )
+    @ApiOperation(value = "안마의자 신청 취소", notes = "안마의자 신청 취소")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
+    public CommonResult cancelMassageMember() {
+        LocalDateTime currentTime = LocalDateTime.now();
+        massageService.cancelMassage(currentTime.getDayOfWeek(), currentTime.getHour(), currentTime.getMinute());
+        return responseService.getSuccessResult();
+    }
+
 }

--- a/src/main/java/com/server/Dotori/model/massage/repository/MassageRepository.java
+++ b/src/main/java/com/server/Dotori/model/massage/repository/MassageRepository.java
@@ -2,6 +2,10 @@ package com.server.Dotori.model.massage.repository;
 
 import com.server.Dotori.model.massage.Massage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface MassageRepository extends JpaRepository<Massage, Long> {
+
+    void deleteByMemberId(Long id);
 }

--- a/src/main/java/com/server/Dotori/model/massage/service/MassageService.java
+++ b/src/main/java/com/server/Dotori/model/massage/service/MassageService.java
@@ -4,5 +4,6 @@ import java.time.DayOfWeek;
 
 public interface MassageService {
     void requestMassage(DayOfWeek dayOfWeek, int hour, int min);
+    void cancelMassage(DayOfWeek dayOfWeek, int hour, int min);
     void updateMassageStatus();
 }

--- a/src/main/java/com/server/Dotori/model/massage/service/MassageServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/massage/service/MassageServiceImpl.java
@@ -1,9 +1,6 @@
 package com.server.Dotori.model.massage.service;
 
-import com.server.Dotori.exception.massage.exception.MassageAlreadyException;
-import com.server.Dotori.exception.massage.exception.MassageCantRequestDateException;
-import com.server.Dotori.exception.massage.exception.MassageCantRequestTimeException;
-import com.server.Dotori.exception.massage.exception.MassageOverException;
+import com.server.Dotori.exception.massage.exception.*;
 import com.server.Dotori.model.massage.repository.MassageRepository;
 import com.server.Dotori.model.member.Member;
 import com.server.Dotori.model.member.repository.member.MemberRepository;
@@ -53,8 +50,27 @@ public class MassageServiceImpl implements MassageService {
     }
 
     @Override
+    public void cancelMassage(DayOfWeek dayOfWeek, int hour, int min) {
+//        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new MassageCantRequestDateException();
+//        if (!(hour >= 20 && hour <= 21)) throw new MassageCantRequestTimeException();
+//        if (!(min >= 20)) throw new MassageCantRequestTimeException();
+
+        long count = massageRepository.count();
+        Member currentMember = currentMemberUtil.getCurrentMember();
+
+        if (currentMember.getMassage() == APPLIED) {
+            currentMember.updateMassage(CANT);
+            massageRepository.deleteByMemberId(currentMember.getId());
+
+            currentMember.updateMassageExpiredDate(null);
+            log.info("Current MassageRequest Student Count is {}", count-1);
+        } else throw new MassageNotAppliedStatusException();
+    }
+
+    @Override
     public void updateMassageStatus() {
         memberRepository.updateUnBanMassage();
+        memberRepository.updateMassageStatusCant();
         massageRepository.deleteAll();
     }
 }

--- a/src/main/java/com/server/Dotori/model/member/repository/member/MemberRepositoryCustom.java
+++ b/src/main/java/com/server/Dotori/model/member/repository/member/MemberRepositoryCustom.java
@@ -25,4 +25,6 @@ public interface MemberRepositoryCustom {
     void updateUnBanSelfStudy();
 
     void updateUnBanMassage();
+
+    void updateMassageStatusCant();
 }

--- a/src/main/java/com/server/Dotori/model/member/repository/member/MemberRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/repository/member/MemberRepositoryImpl.java
@@ -176,4 +176,15 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .execute();
     }
 
+    @Override
+    public void updateMassageStatusCant() {
+        queryFactory
+                .update(member)
+                .where(
+                        member.massage.eq(Massage.CANT)
+                )
+                .set(member.massage, Massage.CAN)
+                .execute();
+    }
+
 }

--- a/src/main/resources/i18n/exception_en.yml
+++ b/src/main/resources/i18n/exception_en.yml
@@ -168,4 +168,8 @@ massage-cant-request-date:
 
 massage-cant-request-time:
   code: "-430"
-  msg: "You can't request massage in this time.""
+  msg: "You can't request massage in this time."
+
+massage-not-applied-status:
+  code: "-440"
+  msg: "You can't cancel massage cuz your status is not applied"

--- a/src/main/resources/i18n/exception_ko.yml
+++ b/src/main/resources/i18n/exception_ko.yml
@@ -169,3 +169,7 @@ massage-cant-request-date:
 massage-cant-request-time:
   code: "-430"
   msg: "안마의자 신청은 오후 8시부터 오후 10시까지만 신청이 가능합니다."
+
+massage-not-applied-status:
+  code: "-440"
+  msg: "안마의자 신청을 취소할 수 있는 상태가 아닙니다."

--- a/src/test/java/com/server/Dotori/model/member/service/massage/MassageServiceTest.java
+++ b/src/test/java/com/server/Dotori/model/member/service/massage/MassageServiceTest.java
@@ -4,6 +4,7 @@ import com.server.Dotori.exception.massage.exception.MassageCantRequestDateExcep
 import com.server.Dotori.exception.massage.exception.MassageCantRequestTimeException;
 import com.server.Dotori.model.massage.repository.MassageRepository;
 import com.server.Dotori.model.massage.service.MassageService;
+import com.server.Dotori.model.member.Member;
 import com.server.Dotori.model.member.dto.MemberDto;
 import com.server.Dotori.model.member.enumType.Massage;
 import com.server.Dotori.model.member.enumType.Role;
@@ -109,5 +110,15 @@ public class MassageServiceTest {
                 .filter(cronTask -> cronTask.getExpression().equals("0 0 2 ? * MON-FRI") && cronTask.toString().equals("com.server.Dotori.model.massage.schedule.MassageSchedule.updateMassageStatus"))
                 .count();
         Assertions.assertThat(count).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("안마의자 신청 취소가 잘 되는지 검증")
+    public void cancelMassageTest() {
+        massageService.requestMassage(DayOfWeek.THURSDAY,20,30);
+        massageService.cancelMassage(DayOfWeek.THURSDAY, 20, 31);
+
+        assertEquals(Massage.CANT, currentMemberUtil.getCurrentMember().getMassage());
+        assertEquals(0, massageRepository.count());
     }
 }


### PR DESCRIPTION
안마의자 신청을 취소하는 로직을 추가하였습니다.
누락된 MassageExceptionController를 작성했습니다.
새로운 Exception을 추가하였습니다. 
안마의자 신청 취소 테스트 케이스를 작성하였습니다.

안마의자 신청 후 DB
![스크린샷 2022-01-26 21 24 18](https://user-images.githubusercontent.com/69895452/151164687-bc2bc18f-d429-4d72-897c-9ea4c9ead391.png)

안마의자 신청 취소 후 DB
![스크린샷 2022-01-26 21 24 38](https://user-images.githubusercontent.com/69895452/151164627-8d55ea8e-6c80-41ab-bcd6-ded58a17dc3a.png)

안마의자 신청을 하지 않고 취소할 시
![스크린샷 2022-01-26 21 27 25](https://user-images.githubusercontent.com/69895452/151164760-1da01323-4b33-4dc5-b587-1ae5a3c2c973.png)

