### PR TITLE
안마의자 신청 전체조회시 APPLIED상태인 모두가 조회되는 점 fix

### DIFF
--- a/src/main/java/com/server/Dotori/model/massage/service/MassageServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/massage/service/MassageServiceImpl.java
@@ -71,12 +71,11 @@ public class MassageServiceImpl implements MassageService {
         } else throw new MassageNotAppliedStatusException();
     }
 
-
-
     @Override
     public void updateMassageStatus() {
         memberRepository.updateUnBanMassage();
         memberRepository.updateMassageStatusCant();
+        memberRepository.updateMassageStatusImpossible();
         massageRepository.deleteAll();
     }
 

--- a/src/main/java/com/server/Dotori/model/member/enumType/Massage.java
+++ b/src/main/java/com/server/Dotori/model/member/enumType/Massage.java
@@ -1,5 +1,5 @@
 package com.server.Dotori.model.member.enumType;
 
 public enum Massage {
-    CAN, APPLIED, CANT
+    CAN, APPLIED, CANT, IMPOSSIBLE
 }

--- a/src/main/java/com/server/Dotori/model/member/repository/member/MemberRepositoryCustom.java
+++ b/src/main/java/com/server/Dotori/model/member/repository/member/MemberRepositoryCustom.java
@@ -29,6 +29,8 @@ public interface MemberRepositoryCustom {
 
     void updateMassageStatusCant();
 
+    void updateMassageStatusImpossible();
+
     List<MassageStudentsDto> findByMassageStatus();
 
     List<Member> findStuInfoByMemberName(String memberName);

--- a/src/main/java/com/server/Dotori/model/member/repository/member/MemberRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/repository/member/MemberRepositoryImpl.java
@@ -169,7 +169,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
         queryFactory
                 .update(member)
                 .where(
-                        member.massage.eq(Massage.APPLIED)
+                        member.massage.eq(Massage.IMPOSSIBLE)
                                 .and(member.massageExpiredDate.stringValue().substring(0,10).eq(String.valueOf(LocalDate.now())))
                 )
                 .set(member.massage, Massage.CAN)
@@ -185,6 +185,17 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                         member.massage.eq(Massage.CANT)
                 )
                 .set(member.massage, Massage.CAN)
+                .execute();
+    }
+
+    @Override
+    public void updateMassageStatusImpossible() {
+        queryFactory
+                .update(member)
+                .where(
+                        member.massage.eq(Massage.APPLIED)
+                )
+                .set(member.massage, Massage.IMPOSSIBLE)
                 .execute();
     }
 


### PR DESCRIPTION
안마의자 신청 로직이 신청시 APPLIED로 상태를 변경하고 한달뒤에 CAN으로 변경하는데
전체조회시 APPLIED 타입으로 조회를 하다보니 이제까지 신청했던 사람 전체가 조회 되는점을 창규씨를 통해 오늘 알아서 긴급히 수정합니다.

죄송합니다 재배포 부탁드립니다 🥲
