### PR TITLE
[Hofix] 규정위반 학생 이름 검색 입력값 조건 변경 (한글자만으로 검색 가능), 컨트롤러 이름 중복 문제 해결

### DIFF
--- a/src/main/java/com/server/Dotori/model/member/repository/member/MemberRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/repository/member/MemberRepositoryImpl.java
@@ -268,7 +268,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .select(Projections.fields(FindStusDto.class,
                         member.id,member.memberName,member.stuNum)
                 )
-                .where(member.memberName.like(memberName))
+                .where(member.memberName.like("%"+memberName+"%"))
                 .orderBy(member.stuNum.asc())
                 .fetch();
     }

--- a/src/main/java/com/server/Dotori/model/rule/controller/councillor/CouncillorRuleController.java
+++ b/src/main/java/com/server/Dotori/model/rule/controller/councillor/CouncillorRuleController.java
@@ -25,7 +25,7 @@ public class CouncillorRuleController {
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
     })
     @GetMapping("/main")
-    public SingleResult<List<FindViolationOfTheRuleResponseDto>> findRuleAtMainPage(){
+    public SingleResult<List<FindViolationOfTheRuleResponseDto>> findRuleAtMainPageCouncillor(){
         return responseService.getSingleResult(ruleService.findRuleAtMainPage());
     }
 }

--- a/src/main/java/com/server/Dotori/model/rule/controller/developer/DeveloperRuleController.java
+++ b/src/main/java/com/server/Dotori/model/rule/controller/developer/DeveloperRuleController.java
@@ -25,7 +25,7 @@ public class DeveloperRuleController {
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
     })
     @GetMapping("/main")
-    public SingleResult<List<FindViolationOfTheRuleResponseDto>> findRuleAtMainPage(){
+    public SingleResult<List<FindViolationOfTheRuleResponseDto>> findRuleAtMainPageDeveloper(){
         return responseService.getSingleResult(ruleService.findRuleAtMainPage());
     }
 }

--- a/src/main/java/com/server/Dotori/model/rule/controller/member/MemberRuleController.java
+++ b/src/main/java/com/server/Dotori/model/rule/controller/member/MemberRuleController.java
@@ -25,7 +25,7 @@ public class MemberRuleController {
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
     })
     @GetMapping("/main")
-    public SingleResult<List<FindViolationOfTheRuleResponseDto>> findRuleAtMainPage(){
+    public SingleResult<List<FindViolationOfTheRuleResponseDto>> findRuleAtMainPageMember(){
         return responseService.getSingleResult(ruleService.findRuleAtMainPage());
     }
 }


### PR DESCRIPTION
### 제가 한 일이에요 !
* 규정위반기능 학생 이름검색 한글자만 입력해도 그 한글자가 포함되는 이름을 모두 조회하도록 변경했습니다.
    * 예) “태” 입력 시 김태민, 정태환, 배태현 등등 조회되게 
* 컨트롤러 이름이 같아서 스프링 자체에서 `_1`, `_2`로 처리하여 언제 이상해질지 몰라 불안해서 fix 했습니다.

> 해결전 스샷 (해결 후에는 아래같은 로그가 뜨지않습니다.)
<img width="1847" alt="스크린샷 2022-02-27 오전 3 55 11" src="https://user-images.githubusercontent.com/69895394/155855947-fdb4668f-e23b-4e97-90a6-c72ea92a8536.png">

새벽이라 모두 자고있어 제 작업영역 아닌 부분 **HOTFIX** 한 점 양해바랍니다. @KyungJunNoh 