### PR TITLE
refresh 구조 변경으로 로그인유지

### DIFF
--- a/src/main/java/com/server/Dotori/model/member/controller/RefreshTokenController.java
+++ b/src/main/java/com/server/Dotori/model/member/controller/RefreshTokenController.java
@@ -8,7 +8,10 @@ import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Map;
@@ -24,18 +27,17 @@ public class RefreshTokenController {
 
     /**
      * 토큰 재발급 Controller
-     * @param request accessToken, refreshToken
+     * @param request refreshToken
      * @return SingleResult
-     * @author 노경준
+     * @author 노경준, 배태현
      */
     @PutMapping("/refresh")
     @ResponseStatus( HttpStatus.OK )
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
-            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = true, dataType = "String", paramType = "header")
     })
     public SingleResult<Map<String, String>> refresh(HttpServletRequest request){
-        Map<String, String> data = refreshTokenService.getRefreshToken(request.getRemoteUser(), jwtTokenProvider.resolveRefreshToken(request));
+        Map<String, String> data = refreshTokenService.getRefreshToken(jwtTokenProvider.resolveRefreshToken(request));
         return responseService.getSingleResult(data);
     }
 

--- a/src/main/java/com/server/Dotori/model/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/server/Dotori/model/member/service/MemberServiceImpl.java
@@ -208,7 +208,7 @@ public class MemberServiceImpl implements MemberService {
         Map<String,String> map = new HashMap<>();
 
         String accessToken = jwtTokenProvider.createToken(member.getEmail(), member.getRoles());
-        String refreshToken = jwtTokenProvider.createRefreshToken();
+        String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail(), member.getRoles());
         member.updateRefreshToken(refreshToken);
 
         map.put("email", member.getEmail());

--- a/src/main/java/com/server/Dotori/model/member/service/RefreshTokenService.java
+++ b/src/main/java/com/server/Dotori/model/member/service/RefreshTokenService.java
@@ -3,5 +3,5 @@ package com.server.Dotori.model.member.service;
 import java.util.Map;
 
 public interface RefreshTokenService {
-    Map<String,String> getRefreshToken(String username, String token);
+    Map<String,String> getRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/server/Dotori/new_exception/ErrorCode.java
+++ b/src/main/java/com/server/Dotori/new_exception/ErrorCode.java
@@ -64,6 +64,7 @@ public enum ErrorCode {
     // *** TOKEN ***
     TOKEN_INVALID(HttpStatus.FORBIDDEN, "변질된 토큰입니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    TOKEN_REFRESH_FAIL(HttpStatus.BAD_REQUEST, "토큰 재발급에 실패했습니다."),
 
 
     // *** RULE ***

--- a/src/main/java/com/server/Dotori/security/SecurityConfig.java
+++ b/src/main/java/com/server/Dotori/security/SecurityConfig.java
@@ -66,6 +66,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/v1/health-check").permitAll()
                 .antMatchers("/v1/members/password/email").permitAll()
                 .antMatchers("/v1/members/password/email/check").permitAll()
+                .antMatchers("/v1/refresh").permitAll()
 
                 // 권한 별 url 접근
                 .antMatchers("/v1/admin/**").hasRole("ADMIN")

--- a/src/main/java/com/server/Dotori/security/exception/ExceptionHandlerFilter.java
+++ b/src/main/java/com/server/Dotori/security/exception/ExceptionHandlerFilter.java
@@ -1,20 +1,12 @@
 package com.server.Dotori.security.exception;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.server.Dotori.exception.token.TokenExceptionHandler;
-import com.server.Dotori.exception.token.exception.InvalidTokenException;
-import com.server.Dotori.new_exception.DotoriException;
 import com.server.Dotori.new_exception.ErrorCode;
 import com.server.Dotori.new_exception.ErrorResponse;
-import com.server.Dotori.new_exception.handler.UnknownExceptionHandler;
-import com.server.Dotori.response.result.CommonResult;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.http.entity.ContentType;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -32,7 +24,6 @@ import static com.server.Dotori.new_exception.ErrorCode.*;
 public class ExceptionHandlerFilter extends OncePerRequestFilter {
 
     private final ObjectMapper objectMapper;
-    private final UnknownExceptionHandler unknownExceptionHandler;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {

--- a/src/main/java/com/server/Dotori/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/server/Dotori/security/jwt/JwtTokenProvider.java
@@ -56,8 +56,12 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public String createRefreshToken(){
-        Claims claims = Jwts.claims().setSubject(null);
+    public String createRefreshToken(String email, List<Role> roles){
+        Claims claims = Jwts.claims().setSubject(email);
+        claims.put("auth", roles.stream()
+                .map(GrantedAuthority::getAuthority)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList()));
 
         Date now = new Date();
         Date validity = new Date(now.getTime() + REFRESH_TOKEN_VALIDATION_SECOND);


### PR DESCRIPTION
### 제가 한 일이에요 !
* 토큰 재발급 실패 ErrorCode 추가 후 변경
* refresh 로직 변경 
    > 서버에서 만료된 accessToken을 받게되면 어떻게 하든 401로 처리되어서 구조를 변경했습니다.
    > refreshToken payload에 어쩔 수 없이 accessToken payload와 같은 정보들을 포함시켰습니다.  
    > refreshToken만 받아서 access,refresh 토큰을 재발급해주도록 처리했습니다. (프론트에서 accessToken 만료 여부 확인 후 요청)

운영서버에 이 내용이 적용된다면
운영 DB에 `update member set MEMBER_REFRESH_TOKEN  = null;` 이와같은 쿼리를 날려줘야합니다.
유저들의 refreshToken을 한번 reset 시켜줘야해요.(payload값 변경으로 인해 refresh 토큰을 비교하는 로직에서 에러날거에요)