### PR TITLE
얼마전에 바뀌였던 token을 refresh 하는 로직을 변경 했습니다.

### DIFF
--- a/src/main/java/com/server/Dotori/domain/member/controller/RefreshTokenController.java
+++ b/src/main/java/com/server/Dotori/domain/member/controller/RefreshTokenController.java
@@ -1,5 +1,6 @@
 package com.server.Dotori.domain.member.controller;
 
+import com.server.Dotori.domain.member.dto.RefreshTokenDto;
 import com.server.Dotori.domain.member.service.RefreshTokenService;
 import com.server.Dotori.global.response.ResponseService;
 import com.server.Dotori.global.response.result.SingleResult;
@@ -8,10 +9,7 @@ import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Map;
@@ -27,17 +25,17 @@ public class RefreshTokenController {
 
     /**
      * 토큰 재발급 Controller
-     * @param request refreshToken
+     * @param request refreshToken, refreshRequestDto
      * @return SingleResult
-     * @author 노경준, 배태현
+     * @author 노경준
      */
     @PutMapping("/refresh")
     @ResponseStatus( HttpStatus.OK )
     @ApiImplicitParams({
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = true, dataType = "String", paramType = "header")
     })
-    public SingleResult<Map<String, String>> refresh(HttpServletRequest request){
-        Map<String, String> data = refreshTokenService.getRefreshToken(jwtTokenProvider.resolveRefreshToken(request));
+    public SingleResult<Map<String, String>> refresh(HttpServletRequest request, @RequestBody RefreshTokenDto refreshTokenDto){
+        Map<String, String> data = refreshTokenService.refreshToken(jwtTokenProvider.resolveRefreshToken(request), refreshTokenDto);
         return responseService.getSingleResult(data);
     }
 

--- a/src/main/java/com/server/Dotori/domain/member/dto/RefreshTokenDto.java
+++ b/src/main/java/com/server/Dotori/domain/member/dto/RefreshTokenDto.java
@@ -3,7 +3,7 @@ package com.server.Dotori.domain.member.dto;
 import lombok.Getter;
 
 @Getter
-public class TokenRefreshDto {
+public class RefreshTokenDto {
 
     private String email;
 

--- a/src/main/java/com/server/Dotori/domain/member/dto/TokenRefreshDto.java
+++ b/src/main/java/com/server/Dotori/domain/member/dto/TokenRefreshDto.java
@@ -1,0 +1,10 @@
+package com.server.Dotori.domain.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TokenRefreshDto {
+
+    private String email;
+
+}

--- a/src/main/java/com/server/Dotori/domain/member/service/RefreshTokenService.java
+++ b/src/main/java/com/server/Dotori/domain/member/service/RefreshTokenService.java
@@ -1,7 +1,9 @@
 package com.server.Dotori.domain.member.service;
 
+import com.server.Dotori.domain.member.dto.RefreshTokenDto;
+
 import java.util.Map;
 
 public interface RefreshTokenService {
-    Map<String,String> getRefreshToken(String refreshToken);
+    Map<String,String> refreshToken(String refreshToken, RefreshTokenDto refreshTokenDto);
 }

--- a/src/main/java/com/server/Dotori/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/server/Dotori/domain/member/service/impl/MemberServiceImpl.java
@@ -209,7 +209,7 @@ public class MemberServiceImpl implements MemberService {
         Map<String,String> map = new HashMap<>();
 
         String accessToken = jwtTokenProvider.createToken(member.getEmail(), member.getRoles());
-        String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail(), member.getRoles());
+        String refreshToken = jwtTokenProvider.createRefreshToken();
         member.updateRefreshToken(refreshToken);
 
         map.put("email", member.getEmail());

--- a/src/main/java/com/server/Dotori/domain/member/service/impl/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/server/Dotori/domain/member/service/impl/RefreshTokenServiceImpl.java
@@ -1,6 +1,7 @@
 package com.server.Dotori.domain.member.service.impl;
 
 import com.server.Dotori.domain.member.Member;
+import com.server.Dotori.domain.member.dto.RefreshTokenDto;
 import com.server.Dotori.domain.member.repository.member.MemberRepository;
 import com.server.Dotori.domain.member.enumType.Role;
 import com.server.Dotori.domain.member.service.RefreshTokenService;
@@ -31,8 +32,8 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
      */
     @Transactional
     @Override
-    public Map<String, String> getRefreshToken(String refreshToken) {
-        String email = jwtTokenProvider.getEmail(refreshToken);
+    public Map<String, String> refreshToken(String refreshToken, RefreshTokenDto refreshTokenDto) {
+        String email = refreshTokenDto.getEmail();
 
         Member findMember = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new DotoriException(MEMBER_NOT_FOUND));
@@ -49,11 +50,11 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
 
         if(findMember.getRefreshToken().equals(refreshToken) && jwtTokenProvider.validateToken(refreshToken)){
             newAccessToken = jwtTokenProvider.createToken(email, roles);
-            newRefreshToken = jwtTokenProvider.createRefreshToken(email, roles);
+            newRefreshToken = jwtTokenProvider.createRefreshToken();
             findMember.updateRefreshToken(newRefreshToken);
             map.put("email", email);
-            map.put("NewAccessToken", "Bearer " + newAccessToken); // NewAccessToken 반환
-            map.put("NewRefreshToken", "Bearer " + newRefreshToken); // NewRefreshToken 반환
+            map.put("NewAccessToken", "Bearer " + newAccessToken);
+            map.put("NewRefreshToken", "Bearer " + newRefreshToken);
             return map;
         }
 

--- a/src/main/java/com/server/Dotori/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/server/Dotori/global/security/jwt/JwtTokenProvider.java
@@ -25,19 +25,16 @@ public class JwtTokenProvider {
     @Value("${security.jwt.token.secretKey}")
     private String secretKey;
 
-    // 토큰 만료 시간
     public static long TOKEN_VALIDATION_SECOND = 1000L * 60 * 60 * 3;  // 3시간을 accessToken 만료 기간으로 잡는다
     public static long REFRESH_TOKEN_VALIDATION_SECOND = TOKEN_VALIDATION_SECOND * 24 * 180; // 6달을 refreshToken 만료 기간으로 잡는다.
 
     private final MyMemberDetails myMemberDetails;
 
-    // secretKey 인코딩
     @PostConstruct
     protected void init() {
         secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
     }
 
-    //
     public String createToken(String email, List<Role> roles) {
         Claims claims = Jwts.claims().setSubject(email);
         claims.put("auth", roles.stream()
@@ -56,18 +53,11 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public String createRefreshToken(String email, List<Role> roles){
-        Claims claims = Jwts.claims().setSubject(email);
-        claims.put("auth", roles.stream()
-                .map(GrantedAuthority::getAuthority)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList()));
-
+    public String createRefreshToken(){
         Date now = new Date();
         Date validity = new Date(now.getTime() + REFRESH_TOKEN_VALIDATION_SECOND);
 
         return Jwts.builder()
-                .setClaims(claims)
                 .setIssuedAt(now)
                 .setExpiration(validity)
                 .signWith(SignatureAlgorithm.HS512, secretKey)
@@ -111,7 +101,7 @@ public class JwtTokenProvider {
 
     public boolean isTokenExpired(String token) {
         final Date expiration = extractAllClaims(token).getExpiration();
-        return expiration.before(new Date()); // 유효하면 true 아니면 false
+        return expiration.before(new Date());
     }
 
     public boolean validateToken(String token) {


### PR DESCRIPTION
### 제가 한 일은요!!
- 얼마전에 바뀌였던 token을 refresh 하는 로직을 재 수정 했습니다.

### 바뀐 후의 로직
1. 만료된 토큰으로 토큰이 필요한 api에 접근한다.
2. 프론트에서 accessToken을 decode 해서 expiredTime 을 가져온 후 만료가 되었다면,
3. 프론트는 리프레쉬 토큰을 헤더에 담고, email도 body에 실어서 재발급 api(/v1/refresh)에 요청을 보낸다.
4. 토큰을 재발급 시켜서 프론트에게 새로운 accessToken, refreshToken, email 을 response 해준다.