### PR TITLE
성별 관련 업데이트

### DIFF
--- a/src/main/java/com/server/Dotori/domain/main_page/dto/GetProfileDto.java
+++ b/src/main/java/com/server/Dotori/domain/main_page/dto/GetProfileDto.java
@@ -1,5 +1,6 @@
 package com.server.Dotori.domain.main_page.dto;
 
+import com.server.Dotori.domain.member.enumType.Gender;
 import lombok.*;
 
 @Getter @Builder
@@ -9,5 +10,6 @@ public class GetProfileDto {
     private Long id;
     private String stuNum;
     private String memberName;
+    private Gender gender;
 }
 

--- a/src/main/java/com/server/Dotori/domain/main_page/service/Impl/MainPageServiceImpl.java
+++ b/src/main/java/com/server/Dotori/domain/main_page/service/Impl/MainPageServiceImpl.java
@@ -19,7 +19,6 @@ public class MainPageServiceImpl implements MainPageService {
      * @return GetAboutPointDto (id, username, stNum, point)
      * @author 배태현
      */
-
     @Override
     public GetProfileDto getMyProfile() {
         return memberRepository.findProfileByMember(currentMemberUtil.getCurrentMember());

--- a/src/main/java/com/server/Dotori/domain/main_page/service/Impl/MainPageServiceImpl.java
+++ b/src/main/java/com/server/Dotori/domain/main_page/service/Impl/MainPageServiceImpl.java
@@ -16,8 +16,8 @@ public class MainPageServiceImpl implements MainPageService {
 
     /**
      * 메인페이지를 조회했을 때 프로필정보를 반환해주는 서비스로직 (로그인된 유저 사용가능)
-     * @return GetAboutPointDto (id, username, stNum, point)
-     * @author 배태현
+     * @return GetAboutPointDto (id, username, stNum, gender)
+     * @author 배태현, 노경준
      */
     @Override
     public GetProfileDto getMyProfile() {

--- a/src/main/java/com/server/Dotori/domain/member/Member.java
+++ b/src/main/java/com/server/Dotori/domain/member/Member.java
@@ -1,16 +1,14 @@
 package com.server.Dotori.domain.member;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.server.Dotori.domain.member.enumType.*;
 import com.server.Dotori.global.entity.BaseTimeEntity;
-import com.server.Dotori.domain.member.enumType.Massage;
-import com.server.Dotori.domain.member.enumType.Music;
-import com.server.Dotori.domain.member.enumType.Role;
-import com.server.Dotori.domain.member.enumType.SelfStudy;
 import com.server.Dotori.domain.rule.RuleViolation;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -30,6 +28,7 @@ import static javax.persistence.GenerationType.IDENTITY;
 @Builder @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@DynamicUpdate
 public class Member extends BaseTimeEntity implements UserDetails {
 
     @Id @GeneratedValue(strategy = IDENTITY)
@@ -59,6 +58,10 @@ public class Member extends BaseTimeEntity implements UserDetails {
 
     @Column(name = "massage_expired_date")
     private LocalDateTime massageExpiredDate;
+
+    @Enumerated(STRING)
+    @Column(name = "member_gender")
+    private Gender gender;
 
     @Enumerated(STRING) @Column(name = "Role")
     @ElementCollection(fetch = FetchType.EAGER)
@@ -158,5 +161,9 @@ public class Member extends BaseTimeEntity implements UserDetails {
 
     public void updateSelfStudyExpiredDate(LocalDateTime selfStudyExpiredDate) {
         this.selfStudyExpiredDate = selfStudyExpiredDate;
+    }
+
+    public void updateMemberGender(Gender gender) {
+        this.gender = gender;
     }
 }

--- a/src/main/java/com/server/Dotori/domain/member/controller/MemberController.java
+++ b/src/main/java/com/server/Dotori/domain/member/controller/MemberController.java
@@ -1,9 +1,6 @@
 package com.server.Dotori.domain.member.controller;
 
-import com.server.Dotori.domain.member.dto.ChangePasswordDto;
-import com.server.Dotori.domain.member.dto.ChangePasswordEmailCheckDto;
-import com.server.Dotori.domain.member.dto.EmailDto;
-import com.server.Dotori.domain.member.dto.WithdrawlDto;
+import com.server.Dotori.domain.member.dto.*;
 import com.server.Dotori.domain.member.service.MemberService;
 import com.server.Dotori.global.response.ResponseService;
 import com.server.Dotori.global.response.result.CommonResult;
@@ -94,6 +91,13 @@ public class MemberController {
     })
     public CommonResult withdrawal(@RequestBody WithdrawlDto withdrawlDto){
         memberService.withdrawal(withdrawlDto);
+        return responseService.getSuccessResult();
+    }
+
+    @PutMapping("/gender")
+    @ApiOperation(value="성별설정")
+    public CommonResult setGender(@RequestBody SetGenderDto setGenderDto){
+        memberService.setGender(setGenderDto);
         return responseService.getSuccessResult();
     }
 }

--- a/src/main/java/com/server/Dotori/domain/member/dto/MemberDto.java
+++ b/src/main/java/com/server/Dotori/domain/member/dto/MemberDto.java
@@ -1,10 +1,7 @@
 package com.server.Dotori.domain.member.dto;
 
 import com.server.Dotori.domain.member.Member;
-import com.server.Dotori.domain.member.enumType.Massage;
-import com.server.Dotori.domain.member.enumType.Music;
-import com.server.Dotori.domain.member.enumType.Role;
-import com.server.Dotori.domain.member.enumType.SelfStudy;
+import com.server.Dotori.domain.member.enumType.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,7 +33,10 @@ public class MemberDto {
     @Pattern(regexp = "^[a-zA-Z0-9]+@gsm.hs.kr$")
     private String email;
 
-    public Member toEntity(String encodePassword){
+    @NotBlank
+    private Gender gender;
+
+    public Member toEntity(String encodePassword, Gender gender){
         return Member.builder()
                 .memberName(memberName)
                 .stuNum(stuNum)
@@ -48,6 +48,7 @@ public class MemberDto {
                 .music(Music.CAN)
                 .selfStudy(SelfStudy.CAN)
                 .point(0L)
+                .gender(gender)
                 .build();
     }
 }

--- a/src/main/java/com/server/Dotori/domain/member/dto/MemberDto.java
+++ b/src/main/java/com/server/Dotori/domain/member/dto/MemberDto.java
@@ -33,7 +33,6 @@ public class MemberDto {
     @Pattern(regexp = "^[a-zA-Z0-9]+@gsm.hs.kr$")
     private String email;
 
-    @NotBlank
     private Gender gender;
 
     public Member toEntity(String encodePassword, Gender gender){

--- a/src/main/java/com/server/Dotori/domain/member/dto/SetGenderDto.java
+++ b/src/main/java/com/server/Dotori/domain/member/dto/SetGenderDto.java
@@ -1,0 +1,10 @@
+package com.server.Dotori.domain.member.dto;
+
+import com.server.Dotori.domain.member.enumType.Gender;
+import lombok.Getter;
+
+@Getter
+public class SetGenderDto {
+    private Long memberId;
+    private Gender gender;
+}

--- a/src/main/java/com/server/Dotori/domain/member/enumType/Gender.java
+++ b/src/main/java/com/server/Dotori/domain/member/enumType/Gender.java
@@ -1,5 +1,5 @@
 package com.server.Dotori.domain.member.enumType;
 
 public enum Gender {
-    MAN,WOMAN,WAIT
+    MAN,WOMAN,PENDING
 }

--- a/src/main/java/com/server/Dotori/domain/member/enumType/Gender.java
+++ b/src/main/java/com/server/Dotori/domain/member/enumType/Gender.java
@@ -1,0 +1,5 @@
+package com.server.Dotori.domain.member.enumType;
+
+public enum Gender {
+    MAN,WOMAN,WAIT
+}

--- a/src/main/java/com/server/Dotori/domain/member/repository/member/MemberRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/domain/member/repository/member/MemberRepositoryImpl.java
@@ -114,7 +114,8 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .select(Projections.constructor(GetProfileDto.class,
                         member.id,
                         member.stuNum,
-                        member.memberName
+                        member.memberName,
+                        member.gender
                 ))
                 .where(member.eq(memberEntity))
                 .fetchOne();

--- a/src/main/java/com/server/Dotori/domain/member/repository/member/MemberRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/domain/member/repository/member/MemberRepositoryImpl.java
@@ -105,8 +105,8 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
     /**
      * 현재 로그인된 유저의 프로필 정보(메인페이지)를 조회하는 query
      * @param memberEntity currentUser
-     * @return GetAboutPointDto (id, username, stNum, point)
-     * @author 배태현
+     * @return GetAboutPointDto (id, username, stNum, gender)
+     * @author 배태현, 노경준
      */
     @Override
     public GetProfileDto findProfileByMember(Member memberEntity) {

--- a/src/main/java/com/server/Dotori/domain/member/service/MemberService.java
+++ b/src/main/java/com/server/Dotori/domain/member/service/MemberService.java
@@ -14,6 +14,5 @@ public interface MemberService {
     void checkEmailChangePassword(ChangePasswordEmailCheckDto verifiedAuthKeyAndChangePasswordDto);
     void logout();
     void withdrawal(WithdrawlDto memberDeleteDto);
-
-
+    void setGender(SetGenderDto setGenderDto);
 }

--- a/src/main/java/com/server/Dotori/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/server/Dotori/domain/member/service/impl/MemberServiceImpl.java
@@ -3,6 +3,7 @@ package com.server.Dotori.domain.member.service.impl;
 import com.server.Dotori.domain.member.EmailCertificate;
 import com.server.Dotori.domain.member.Member;
 import com.server.Dotori.domain.member.dto.*;
+import com.server.Dotori.domain.member.enumType.Gender;
 import com.server.Dotori.domain.member.repository.email.EmailCertificateRepository;
 import com.server.Dotori.domain.member.repository.member.MemberRepository;
 import com.server.Dotori.domain.member.service.MemberService;
@@ -22,7 +23,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.server.Dotori.global.exception.ErrorCode.*;
-
 
 @RequiredArgsConstructor
 @Service
@@ -47,12 +47,13 @@ public class MemberServiceImpl implements MemberService {
         String stuNum = memberDto.getStuNum();
         String password = memberDto.getPassword();
         String email = memberDto.getEmail();
+        Gender gender = memberDto.getGender();
 
         try {
             if(!emailCertificateRepository.existsByEmail(email)){
                 if (!memberRepository.existsByEmailAndStuNum(email, stuNum)) {
                     Member result = memberRepository.save(
-                            memberDto.toEntity(passwordEncoder.encode(password))
+                            memberDto.toEntity(passwordEncoder.encode(password), gender)
                     );
                     return result.getId();
                 } else throw new DotoriException(MEMBER_ALREADY);

--- a/src/main/java/com/server/Dotori/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/server/Dotori/domain/member/service/impl/MemberServiceImpl.java
@@ -199,6 +199,14 @@ public class MemberServiceImpl implements MemberService {
         memberRepository.delete(findMember);
     }
 
+    @Transactional
+    @Override
+    public void setGender(SetGenderDto setGenderDto) {
+        Member member = memberRepository.findById(setGenderDto.getMemberId()).get();
+
+        member.updateMemberGender(setGenderDto.getGender());
+    }
+
     /**
      * 토큰을 생성하는 private 메서드
      * @param member

--- a/src/main/java/com/server/Dotori/global/config/dev/GenerateMember.java
+++ b/src/main/java/com/server/Dotori/global/config/dev/GenerateMember.java
@@ -2,6 +2,7 @@ package com.server.Dotori.global.config.dev;
 
 import com.server.Dotori.domain.member.Member;
 import com.server.Dotori.domain.member.dto.MemberDto;
+import com.server.Dotori.domain.member.enumType.Gender;
 import com.server.Dotori.domain.member.enumType.Massage;
 import com.server.Dotori.domain.member.enumType.Music;
 import com.server.Dotori.domain.member.enumType.SelfStudy;
@@ -42,26 +43,45 @@ public class GenerateMember {
         Member councillor = createCouncillorAccount();
 
         // 4기 server developer
-        Member taehyeon = createTaehyeonAccount();
-        Member taemin = createTaeminAccount();
-        Member kyungjun = createKyungjunAccount();
+        Member taehyeon = createAccount(3L,"배태현", "3311", "s20032@gsm.hs.kr", Gender.MAN);
+        Member taemin = createAccount(4L,"김태민", "3405", "s20014@gsm.hs.kr", Gender.MAN);
+        Member kyungjun = createAccount(5L,"노경준", "3203", "s20018@gsm.hs.kr", Gender.MAN);
 
         // 4기 client developer
-        createChanggyuAccount();
-        createTaehwanAccount();
-        createGihongAccount();
-        createJinguAccount();
+        createAccount(6L,"임창규","3214","s20058@gsm.hs.kr", Gender.MAN);
+        createAccount(7L,"정태환","3415","s20069@gsm.hs.kr", Gender.MAN);
+        createAccount(8L,"김기홍","3302","s20005@gsm.hs.kr", Gender.MAN);
+        createAccount(9L,"권진구","3401","s20004@gsm.hs.kr", Gender.MAN);
 
         // 5기 server developer
-        Member seoungone = createSeoungOneAccount();
-        Member jaeyoung = createJaeYoungAccount();
+        Member seoungone = createAccount(10L,"전승원", "2218","s21034@gsm.hs.kr", Gender.MAN);
+        Member jaeyoung = createAccount(11L,"조재영", "2116", "s21053@gsm.hs.kr", Gender.MAN);
 
         // 5기 client developer
-        createHwanBinAccount();
-        createJeongMinAccount();
-        createKyeoungMinAccount();
+        createAccount(12L,"유환빈", "2308", "s21067@gsm.hs.kr", Gender.MAN);
+        createAccount(13L,"손정민", "2215", "s21062@gsm.hs.kr", Gender.MAN);
+        createAccount(14L,"강경민", "2201", "s21038@gsm.hs.kr", Gender.MAN);
 
         loggingAccessToken(admin, developer, councillor, taehyeon, taemin, kyungjun, seoungone, jaeyoung);
+    }
+
+    private Member createAccount(Long id, String name, String stuNum, String email, Gender gender) {
+        return memberRepository.save(
+                Member.builder()
+                        .id(id)
+                        .memberName(name)
+                        .stuNum(stuNum)
+                        .email(email)
+                        .password(passwordEncoder.encode("string"))
+                        .point(0L)
+                        .refreshToken(null)
+                        .roles(singletonList(ROLE_DEVELOPER))
+                        .selfStudy(SelfStudy.CAN)
+                        .music(Music.CAN)
+                        .massage(Massage.CAN)
+                        .gender(gender)
+                        .build()
+        );
     }
 
     private Member createAdminAccount() {
@@ -78,6 +98,7 @@ public class GenerateMember {
                         .selfStudy(SelfStudy.CAN)
                         .music(Music.CAN)
                         .massage(Massage.CAN)
+                        .gender(Gender.WAIT)
                         .build()
         );
     }
@@ -96,6 +117,7 @@ public class GenerateMember {
                         .selfStudy(SelfStudy.CAN)
                         .music(Music.CAN)
                         .massage(Massage.CAN)
+                        .gender(Gender.WAIT)
                         .build()
         );
     }
@@ -114,182 +136,7 @@ public class GenerateMember {
                         .selfStudy(SelfStudy.CAN)
                         .music(Music.CAN)
                         .massage(Massage.CAN)
-                        .build()
-        );
-    }
-
-    private Member createTaehyeonAccount() {
-        return memberRepository.save(
-                MemberDto.builder()
-                .memberName("배태현")
-                .stuNum("3311")
-                .email("s20032@gsm.hs.kr")
-                .build().toEntity(passwordEncoder.encode("string"))
-        );
-    }
-
-    private Member createTaeminAccount() {
-        return memberRepository.save(
-                MemberDto.builder()
-                        .memberName("김태민")
-                        .stuNum("3405")
-                        .email("s20014@gsm.hs.kr")
-                        .build().toEntity(passwordEncoder.encode("string"))
-        );
-    }
-
-    private Member createKyungjunAccount() {
-        return memberRepository.save(
-                MemberDto.builder()
-                        .memberName("노경준")
-                        .stuNum("3203")
-                        .email("s20018@gsm.hs.kr")
-                        .build().toEntity(passwordEncoder.encode("string"))
-        );
-    }
-
-    private void createChanggyuAccount() {
-        memberRepository.save(
-                Member.builder()
-                        .id(7L)
-                        .memberName("임창규")
-                        .stuNum("3214")
-                        .email("s20058@gsm.hs.kr")
-                        .password(passwordEncoder.encode("string"))
-                        .point(0L)
-                        .refreshToken(null)
-                        .roles(singletonList(ROLE_DEVELOPER))
-                        .selfStudy(SelfStudy.CAN)
-                        .music(Music.CAN)
-                        .massage(Massage.CAN)
-                        .build()
-        );
-    }
-
-    private void createTaehwanAccount() {
-        memberRepository.save(
-                Member.builder()
-                        .id(8L)
-                        .memberName("정태환")
-                        .stuNum("3415")
-                        .email("s20069@gsm.hs.kr")
-                        .password(passwordEncoder.encode("string"))
-                        .point(0L)
-                        .refreshToken(null)
-                        .roles(singletonList(ROLE_DEVELOPER))
-                        .selfStudy(SelfStudy.CAN)
-                        .music(Music.CAN)
-                        .massage(Massage.CAN)
-                        .build()
-        );
-    }
-
-    private void createGihongAccount() {
-        memberRepository.save(
-                Member.builder()
-                        .id(9L)
-                        .memberName("김기홍")
-                        .stuNum("3302")
-                        .email("s20005@gsm.hs.kr")
-                        .password(passwordEncoder.encode("string"))
-                        .point(0L)
-                        .refreshToken(null)
-                        .roles(singletonList(ROLE_DEVELOPER))
-                        .selfStudy(SelfStudy.CAN)
-                        .music(Music.CAN)
-                        .massage(Massage.CAN)
-                        .build()
-        );
-    }
-
-    private void createJinguAccount() {
-        memberRepository.save(
-                Member.builder()
-                        .id(10L)
-                        .memberName("권진구")
-                        .stuNum("3401")
-                        .email("s20004@gsm.hs.kr")
-                        .password(passwordEncoder.encode("string"))
-                        .point(0L)
-                        .refreshToken(null)
-                        .roles(singletonList(ROLE_DEVELOPER))
-                        .selfStudy(SelfStudy.CAN)
-                        .music(Music.CAN)
-                        .massage(Massage.CAN)
-                        .build()
-        );
-    }
-
-    private Member createSeoungOneAccount() {
-        return memberRepository.save(
-                MemberDto.builder()
-                        .memberName("전승원")
-                        .stuNum("2218")
-                        .email("s21034@gsm.hs.kr")
-                        .build().toEntity(passwordEncoder.encode("string"))
-        );
-    }
-
-    private Member createJaeYoungAccount() {
-        return memberRepository.save(
-                MemberDto.builder()
-                        .memberName("조재영")
-                        .stuNum("2116")
-                        .email("s21053@gsm.hs.kr")
-                        .build().toEntity(passwordEncoder.encode("string"))
-        );
-    }
-
-    private void createHwanBinAccount() {
-        memberRepository.save(
-                Member.builder()
-                        .id(13L)
-                        .memberName("유환빈")
-                        .stuNum("2308")
-                        .email("s21067@gsm.hs.kr")
-                        .password(passwordEncoder.encode("string"))
-                        .point(0L)
-                        .refreshToken(null)
-                        .roles(singletonList(ROLE_DEVELOPER))
-                        .selfStudy(SelfStudy.CAN)
-                        .music(Music.CAN)
-                        .massage(Massage.CAN)
-                        .build()
-        );
-    }
-
-    private void createJeongMinAccount() {
-        memberRepository.save(
-                Member.builder()
-                        .id(14L)
-                        .memberName("손정민")
-                        .stuNum("2215")
-                        .email("s21062@gsm.hs.kr")
-                        .password(passwordEncoder.encode("string"))
-                        .point(0L)
-                        .refreshToken(null)
-                        .roles(singletonList(ROLE_DEVELOPER))
-                        .selfStudy(SelfStudy.CAN)
-                        .music(Music.CAN)
-                        .massage(Massage.CAN)
-                        .build()
-        );
-    }
-
-    private void createKyeoungMinAccount() {
-        memberRepository.save(
-                Member.builder()
-                        .id(15L)
-                        .memberName("강경민")
-                        .stuNum("2201")
-                        .email("s21038@gsm.hs.kr")
-                        .password(passwordEncoder.encode("string"))
-                        .point(0L)
-                        .refreshToken(null)
-                        .roles(singletonList(ROLE_DEVELOPER))
-                        .selfStudy(SelfStudy.CAN)
-                        .music(Music.CAN)
-                        .massage(Massage.CAN)
+                        .gender(Gender.WAIT)
                         .build()
         );
     }

--- a/src/main/java/com/server/Dotori/global/config/dev/GenerateMember.java
+++ b/src/main/java/com/server/Dotori/global/config/dev/GenerateMember.java
@@ -97,7 +97,7 @@ public class GenerateMember {
                         .selfStudy(SelfStudy.CAN)
                         .music(Music.CAN)
                         .massage(Massage.CAN)
-                        .gender(Gender.WAIT)
+                        .gender(Gender.PENDING)
                         .build()
         );
     }
@@ -116,7 +116,7 @@ public class GenerateMember {
                         .selfStudy(SelfStudy.CAN)
                         .music(Music.CAN)
                         .massage(Massage.CAN)
-                        .gender(Gender.WAIT)
+                        .gender(Gender.PENDING)
                         .build()
         );
     }
@@ -135,7 +135,7 @@ public class GenerateMember {
                         .selfStudy(SelfStudy.CAN)
                         .music(Music.CAN)
                         .massage(Massage.CAN)
-                        .gender(Gender.WAIT)
+                        .gender(Gender.PENDING)
                         .build()
         );
     }

--- a/src/main/java/com/server/Dotori/global/config/dev/GenerateMember.java
+++ b/src/main/java/com/server/Dotori/global/config/dev/GenerateMember.java
@@ -1,7 +1,6 @@
 package com.server.Dotori.global.config.dev;
 
 import com.server.Dotori.domain.member.Member;
-import com.server.Dotori.domain.member.dto.MemberDto;
 import com.server.Dotori.domain.member.enumType.Gender;
 import com.server.Dotori.domain.member.enumType.Massage;
 import com.server.Dotori.domain.member.enumType.Music;

--- a/src/main/java/com/server/Dotori/global/security/SecurityConfig.java
+++ b/src/main/java/com/server/Dotori/global/security/SecurityConfig.java
@@ -66,6 +66,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/v1/health-check").permitAll()
                 .antMatchers("/v1/members/password/email").permitAll()
                 .antMatchers("/v1/members/password/email/check").permitAll()
+                .antMatchers("/v1/members/gender").permitAll()
                 .antMatchers("/v1/refresh").permitAll()
                 .antMatchers("/v1/board/count").permitAll()
 


### PR DESCRIPTION
### 제가 한 일은요!!
- Gender 컬럼을 추가했습니다.
- 이제부터 성별이 필요하기 때문에 회원가입 된 유저들은 Gender의 상태가 PENDING 이고 메인페이지에 들어갔을때 Pending 인 멤버들은 성별을 변경할 수 있는 api 인 setGender api를 사용하여 Gender를 설정해줄 수 있습니다.
- 이제 회원가입 할때도 성별을 받습니다.
- gereateMember 코드에서 중복되는 부분이 많아서 수정했습니다.

### 이 PR 이 머지가 되면
- 현재 변경사항이 너무 많아서 에러가나는 테스트 코드들은 다음 pr로 바로 올리겠습니다. ( 그래서 이번 pr에서는 OK 라벨을 달지 않겠습니다 )
<img width="682" alt="2022-04-09_17-34-29" src="https://user-images.githubusercontent.com/68670670/162563716-556d0800-aadf-4512-bbef-92636decd74b.png">
- 각자 자기가 맡은 테스트코드 에서 currentMember을 gender를 추가해주세요. 추가할 부분이 너무 많아서 각자 부탁드립니다. 
( 꼭 안해도 되지만 하는걸 추천드립니다. )



