### PR TITLE
안마의자 신청 상태반환 api에 만료 기간일도 추가

### DIFF
--- a/src/main/java/com/server/Dotori/domain/massage/controller/admin/AdminMassageController.java
+++ b/src/main/java/com/server/Dotori/domain/massage/controller/admin/AdminMassageController.java
@@ -39,17 +39,17 @@ public class AdminMassageController {
     }
 
     /**
-     * 안마의자를 신청한 학생수와 자신의 신청 상태 조회
-     * @return Map<String count(안마의자 신청을 한 학생수), String massageStatus(자신의 안마의자 신청 상태)>
+     * 안마의자를 신청한 학생수와 자신의 신청 상태와 안마의자 신청 금지 만료일 조회
+     * @return Map<String count(안마의자 신청을 한 학생수), String massageStatus(자신의 안마의자 신청 상태), String expiredTime(안마의자 신청 금지 만료일)>
      */
     @GetMapping ("/massage/info")
     @ResponseStatus( HttpStatus.OK )
-    @ApiOperation(value = "안마의자를 신청한 학생 카운트, 안마의자 신청 상태 조회", notes = "안마의자를 신청한 학생 카운트, 안마의자 신청 상태 조회")
+    @ApiOperation(value = "안마의자를 신청한 학생 카운트, 안마의자 신청 상태 조회, 안마의자 신청 금지 만료일", notes = "안마의자를 신청한 학생 카운트, 안마의자 신청 상태 조회, 안마의자 신청 금지 만료일")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
-    public SingleResult<Map<String, String>> getMassageStatusAndCountAdmin() {
+    public SingleResult<Map<String, String>> getMassageInfoAdmin() {
         return responseService.getSingleResult(massageService.getMassageInfo());
     }
 }

--- a/src/main/java/com/server/Dotori/domain/massage/controller/admin/AdminMassageController.java
+++ b/src/main/java/com/server/Dotori/domain/massage/controller/admin/AdminMassageController.java
@@ -50,6 +50,6 @@ public class AdminMassageController {
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
     public SingleResult<Map<String, String>> getMassageStatusAndCountAdmin() {
-        return responseService.getSingleResult(massageService.getMassageStatusAndCount());
+        return responseService.getSingleResult(massageService.getMassageInfo());
     }
 }

--- a/src/main/java/com/server/Dotori/domain/massage/controller/councillor/CouncillorMassageController.java
+++ b/src/main/java/com/server/Dotori/domain/massage/controller/councillor/CouncillorMassageController.java
@@ -85,7 +85,7 @@ public class CouncillorMassageController {
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
     public SingleResult<Map<String, String>> getMassageStatusAndCountCouncillor() {
-        return responseService.getSingleResult(massageService.getMassageStatusAndCount());
+        return responseService.getSingleResult(massageService.getMassageInfo());
     }
 
 }

--- a/src/main/java/com/server/Dotori/domain/massage/controller/councillor/CouncillorMassageController.java
+++ b/src/main/java/com/server/Dotori/domain/massage/controller/councillor/CouncillorMassageController.java
@@ -74,17 +74,17 @@ public class CouncillorMassageController {
     }
 
     /**
-     * 안마의자를 신청한 학생수와 자신의 신청 상태 조회
-     * @return Map<String count(안마의자 신청을 한 학생수), String massageStatus(자신의 안마의자 신청 상태)>
+     * 안마의자를 신청한 학생수와 자신의 신청 상태와 안마의자 신청 금지 만료일 조회
+     * @return Map<String count(안마의자 신청을 한 학생수), String massageStatus(자신의 안마의자 신청 상태), String expiredTime(안마의자 신청 금지 만료일)>
      */
     @GetMapping ("/massage/info")
     @ResponseStatus( HttpStatus.OK )
-    @ApiOperation(value = "안마의자를 신청한 학생 카운트, 안마의자 신청 상태 조회", notes = "안마의자를 신청한 학생 카운트, 안마의자 신청 상태 조회")
+    @ApiOperation(value = "안마의자를 신청한 학생 카운트, 안마의자 신청 상태 조회, 안마의자 신청 금지 만료일", notes = "안마의자를 신청한 학생 카운트, 안마의자 신청 상태 조회, 안마의자 신청 금지 만료일")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
-    public SingleResult<Map<String, String>> getMassageStatusAndCountCouncillor() {
+    public SingleResult<Map<String, String>> getMassageInfoCouncillor() {
         return responseService.getSingleResult(massageService.getMassageInfo());
     }
 

--- a/src/main/java/com/server/Dotori/domain/massage/controller/developer/DeveloperMassageController.java
+++ b/src/main/java/com/server/Dotori/domain/massage/controller/developer/DeveloperMassageController.java
@@ -85,6 +85,6 @@ public class DeveloperMassageController {
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
     public SingleResult<Map<String, String>> getMassageStatusAndCountDeveloper() {
-        return responseService.getSingleResult(massageService.getMassageStatusAndCount());
+        return responseService.getSingleResult(massageService.getMassageInfo());
     }
 }

--- a/src/main/java/com/server/Dotori/domain/massage/controller/developer/DeveloperMassageController.java
+++ b/src/main/java/com/server/Dotori/domain/massage/controller/developer/DeveloperMassageController.java
@@ -74,17 +74,17 @@ public class DeveloperMassageController {
     }
 
     /**
-     * 안마의자를 신청한 학생수와 자신의 신청 상태 조회
-     * @return Map<String count(안마의자 신청을 한 학생수), String massageStatus(자신의 안마의자 신청 상태)>
+     * 안마의자를 신청한 학생수와 자신의 신청 상태와 안마의자 신청 금지 만료일 조회
+     * @return Map<String count(안마의자 신청을 한 학생수), String massageStatus(자신의 안마의자 신청 상태), String expiredTime(안마의자 신청 금지 만료일)>
      */
     @GetMapping ("/massage/info")
     @ResponseStatus( HttpStatus.OK )
-    @ApiOperation(value = "안마의자를 신청한 학생 카운트, 안마의자 신청 상태 조회", notes = "안마의자를 신청한 학생 카운트, 안마의자 신청 상태 조회")
+    @ApiOperation(value = "안마의자를 신청한 학생 카운트, 안마의자 신청 상태 조회, 안마의자 신청 금지 만료일", notes = "안마의자를 신청한 학생 카운트, 안마의자 신청 상태 조회, 안마의자 신청 금지 만료일")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
-    public SingleResult<Map<String, String>> getMassageStatusAndCountDeveloper() {
+    public SingleResult<Map<String, String>> getMassageInfoDeveloper() {
         return responseService.getSingleResult(massageService.getMassageInfo());
     }
 }

--- a/src/main/java/com/server/Dotori/domain/massage/controller/member/MemberMassageController.java
+++ b/src/main/java/com/server/Dotori/domain/massage/controller/member/MemberMassageController.java
@@ -74,17 +74,17 @@ public class MemberMassageController {
     }
 
     /**
-     * 안마의자를 신청한 학생수와 자신의 신청 상태 조회
-     * @return Map<String count(안마의자 신청을 한 학생수), String massageStatus(자신의 안마의자 신청 상태)>
+     * 안마의자를 신청한 학생수와 자신의 신청 상태와 안마의자 신청 금지 만료일 조회
+     * @return Map<String count(안마의자 신청을 한 학생수), String massageStatus(자신의 안마의자 신청 상태), String expiredTime(안마의자 신청 금지 만료일)>
      */
     @GetMapping ("/massage/info")
     @ResponseStatus( HttpStatus.OK )
-    @ApiOperation(value = "안마의자를 신청한 학생 카운트, 안마의자 신청 상태 조회", notes = "안마의자를 신청한 학생 카운트, 안마의자 신청 상태 조회")
+    @ApiOperation(value = "안마의자를 신청한 학생 카운트, 안마의자 신청 상태 조회, 안마의자 신청 금지 만료일", notes = "안마의자를 신청한 학생 카운트, 안마의자 신청 상태 조회, 안마의자 신청 금지 만료일")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
-    public SingleResult<Map<String, String>> getMassageStatusAndCountMember() {
+    public SingleResult<Map<String, String>> getMassageInfoMember() {
         return responseService.getSingleResult(massageService.getMassageInfo());
     }
 

--- a/src/main/java/com/server/Dotori/domain/massage/controller/member/MemberMassageController.java
+++ b/src/main/java/com/server/Dotori/domain/massage/controller/member/MemberMassageController.java
@@ -85,7 +85,7 @@ public class MemberMassageController {
             @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
     })
     public SingleResult<Map<String, String>> getMassageStatusAndCountMember() {
-        return responseService.getSingleResult(massageService.getMassageStatusAndCount());
+        return responseService.getSingleResult(massageService.getMassageInfo());
     }
 
 }

--- a/src/main/java/com/server/Dotori/domain/massage/service/MassageService.java
+++ b/src/main/java/com/server/Dotori/domain/massage/service/MassageService.java
@@ -11,5 +11,5 @@ public interface MassageService {
     void cancelMassage(DayOfWeek dayOfWeek, int hour, int min);
     void updateMassageStatus();
     List<MassageStudentsDto> getMassageStudents();
-    Map<String, String> getMassageStatusAndCount();
+    Map<String, String> getMassageInfo();
 }

--- a/src/test/java/com/server/Dotori/domain/massage/service/MassageServiceTest.java
+++ b/src/test/java/com/server/Dotori/domain/massage/service/MassageServiceTest.java
@@ -117,7 +117,7 @@ public class MassageServiceTest {
     @DisplayName("안마의자를 신청한 학생의 상태와 안마의자 신청 카운트 조회가 잘 되나요?")
     public void findMassageStatusAndCountTest() {
         massageService.requestMassage(DayOfWeek.THURSDAY, 20, 40);
-        Map<String, String> find = massageService.getMassageStatusAndCount();
+        Map<String, String> find = massageService.getMassageInfo();
 
         assertEquals(String.valueOf(Massage.APPLIED), find.get("status"));
         assertEquals("1", find.get("count"));


### PR DESCRIPTION
메인페이지에서 안마의자 카운트와 상태반환 api에 만료기간일을 추가로 넣어서 반환하였습니다.
안마의자 신청 시간검증 부분을 캡슐화 하였습니다.
확장에 따른 이유로 안마의자 상태 반환 api의 네이밍을 변경하였습니다