### PR TITLE
학생정보 성별 변경, 자습신청 목록 성별 추가

### DIFF
--- a/src/main/java/com/server/Dotori/domain/member/repository/member/MemberRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/domain/member/repository/member/MemberRepositoryImpl.java
@@ -36,7 +36,9 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .select(Projections.fields(SelfStudyStudentsDto.class,
                         member.id,
                         member.stuNum,
-                        member.memberName)
+                        member.memberName,
+                        member.gender
+                        )
                 ).where(
                         member.selfStudy.eq(SelfStudy.APPLIED)
                 )
@@ -56,7 +58,10 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .select(Projections.fields(SelfStudyStudentsDto.class,
                         member.id,
                         member.stuNum,
-                        member.memberName))
+                        member.memberName,
+                        member.gender
+                        )
+                )
                 .where(
                         member.selfStudy.eq(SelfStudy.APPLIED)
                         .and(member.stuNum.like(id+"%"))

--- a/src/main/java/com/server/Dotori/domain/self_study/dto/SelfStudyStudentsDto.java
+++ b/src/main/java/com/server/Dotori/domain/self_study/dto/SelfStudyStudentsDto.java
@@ -1,19 +1,17 @@
 package com.server.Dotori.domain.self_study.dto;
 
+import com.server.Dotori.domain.member.enumType.Gender;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
+@AllArgsConstructor
 @NoArgsConstructor
 public class SelfStudyStudentsDto {
 
     private Long id;
     private String stuNum;
     private String memberName;
-
-    public SelfStudyStudentsDto(Long id, String stuNum, String memberName) {
-        this.id = id;
-        this.stuNum = stuNum;
-        this.memberName = memberName;
-    }
+    private Gender gender;
 }

--- a/src/main/java/com/server/Dotori/domain/self_study/repository/SelfStudyRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/domain/self_study/repository/SelfStudyRepositoryImpl.java
@@ -22,7 +22,9 @@ public class SelfStudyRepositoryImpl implements SelfStudyRepositoryCustom {
                 .select(Projections.fields(SelfStudyStudentsDto.class,
                         selfStudy.member.id,
                         selfStudy.member.stuNum,
-                        selfStudy.member.memberName)
+                        selfStudy.member.memberName,
+                        selfStudy.member.gender
+                        )
                 )
                 .where(
                         selfStudy.member.selfStudy.eq(SelfStudy.APPLIED)

--- a/src/main/java/com/server/Dotori/domain/self_study/service/Impl/SelfStudyServiceImpl.java
+++ b/src/main/java/com/server/Dotori/domain/self_study/service/Impl/SelfStudyServiceImpl.java
@@ -49,8 +49,8 @@ public class SelfStudyServiceImpl implements SelfStudyService {
     @Override
     @Transactional
     public void requestSelfStudy(DayOfWeek dayOfWeek, int hour) {
-//        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new DotoriException(SELF_STUDY_CANT_REQUEST_DATE);
-//        if (!(hour >= 20 && hour < 21)) throw new DotoriException(SELF_STUDY_CANT_REQUEST_TIME); // 20시(8시)부터 21시(9시 (8시 59분)) 사이가 아니라면 자습신청 불가능
+        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new DotoriException(SELF_STUDY_CANT_REQUEST_DATE);
+        if (!(hour >= 20 && hour < 21)) throw new DotoriException(SELF_STUDY_CANT_REQUEST_TIME); // 20시(8시)부터 21시(9시 (8시 59분)) 사이가 아니라면 자습신청 불가능
 
         Member currentMember = currentMemberUtil.getCurrentMember();
         long count = selfStudyRepository.count();
@@ -105,7 +105,7 @@ public class SelfStudyServiceImpl implements SelfStudyService {
 
     /**
      * 자습신청한 학생을 전체 조회하는 서비스로직 (로그인된 유저 사용가능)
-     * @return List - SelfStudyStudentDto (id, stuNum, username)
+     * @return List - SelfStudyStudentDto (id, stuNum, username, gender)
      * @exception DotoriException (SELF_STUDY_NOT_FOUND) 자습신청한 학생이 없을 때
      * @author 배태현
      */
@@ -120,7 +120,7 @@ public class SelfStudyServiceImpl implements SelfStudyService {
 
     /**
      * 자습신청 한 학생들 자습신청 한 순서대로 전체조회하는 서비스 로직 (로그인된 유저 사용가능)
-     * @return List - SelfStudyStudentDto (id, stuNum, username)
+     * @return List - SelfStudyStudentDto (id, stuNum, username, gender)
      * @exception DotoriException (SELF_STUDY_NOT_FOUND) 자습신청한 학생이 없을 때
      * @author 배태현
      */
@@ -136,7 +136,7 @@ public class SelfStudyServiceImpl implements SelfStudyService {
     /**
      * 자습신청한 학생을 학년반별로 조회하는 서비스로직 (로그인된 유저 사용가능)
      * @param id classId
-     * @return List - SelfStudyStudentDto (id, stuNum, username)
+     * @return List - SelfStudyStudentDto (id, stuNum, username, gender)
      * @exception DotoriException (MEMBER_NOT_FOUND_BY_CLASS) 해당 반에 해당하는 학생이 없을 때
      * @author 배태현
      */

--- a/src/main/java/com/server/Dotori/domain/self_study/service/Impl/SelfStudyServiceImpl.java
+++ b/src/main/java/com/server/Dotori/domain/self_study/service/Impl/SelfStudyServiceImpl.java
@@ -49,8 +49,8 @@ public class SelfStudyServiceImpl implements SelfStudyService {
     @Override
     @Transactional
     public void requestSelfStudy(DayOfWeek dayOfWeek, int hour) {
-        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new DotoriException(SELF_STUDY_CANT_REQUEST_DATE);
-        if (!(hour >= 20 && hour < 21)) throw new DotoriException(SELF_STUDY_CANT_REQUEST_TIME); // 20시(8시)부터 21시(9시 (8시 59분)) 사이가 아니라면 자습신청 불가능
+//        if (dayOfWeek == DayOfWeek.FRIDAY || dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) throw new DotoriException(SELF_STUDY_CANT_REQUEST_DATE);
+//        if (!(hour >= 20 && hour < 21)) throw new DotoriException(SELF_STUDY_CANT_REQUEST_TIME); // 20시(8시)부터 21시(9시 (8시 59분)) 사이가 아니라면 자습신청 불가능
 
         Member currentMember = currentMemberUtil.getCurrentMember();
         long count = selfStudyRepository.count();

--- a/src/main/java/com/server/Dotori/domain/stu_info/controller/admin/AdminStuInfoController.java
+++ b/src/main/java/com/server/Dotori/domain/stu_info/controller/admin/AdminStuInfoController.java
@@ -1,5 +1,6 @@
 package com.server.Dotori.domain.stu_info.controller.admin;
 
+import com.server.Dotori.domain.stu_info.dto.GenderUpdateDto;
 import com.server.Dotori.domain.stu_info.dto.MemberNameUpdateDto;
 import com.server.Dotori.domain.stu_info.dto.RoleUpdateDto;
 import com.server.Dotori.domain.stu_info.dto.StuNumUpdateDto;
@@ -108,6 +109,24 @@ public class AdminStuInfoController {
     })
     public CommonResult updateMemberNameAdmin(@Valid @RequestBody MemberNameUpdateDto memberNameUpdateDto) {
         stuInfoService.updateMemberName(memberNameUpdateDto);
+        return responseService.getSuccessResult();
+    }
+
+    /**
+     * 학생 정보 변경 - 성별 변경
+     * @param genderUpdateDto (receiverId, gender)
+     * @return CommonResult - SuccessResult
+     * @author 배태현
+     */
+    @PutMapping("/info/gender")
+    @ResponseStatus( HttpStatus.OK )
+    @ApiOperation(value = "성별 변경", notes = "성별 변경")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
+    public CommonResult updateGenderAdmin(@Valid @RequestBody GenderUpdateDto genderUpdateDto) {
+        stuInfoService.updateGender(genderUpdateDto);
         return responseService.getSuccessResult();
     }
 

--- a/src/main/java/com/server/Dotori/domain/stu_info/controller/councillor/CouncillorStuInfoController.java
+++ b/src/main/java/com/server/Dotori/domain/stu_info/controller/councillor/CouncillorStuInfoController.java
@@ -1,5 +1,6 @@
 package com.server.Dotori.domain.stu_info.controller.councillor;
 
+import com.server.Dotori.domain.stu_info.dto.GenderUpdateDto;
 import com.server.Dotori.domain.stu_info.dto.MemberNameUpdateDto;
 import com.server.Dotori.domain.stu_info.dto.RoleUpdateDto;
 import com.server.Dotori.domain.stu_info.dto.StuNumUpdateDto;
@@ -108,6 +109,24 @@ public class CouncillorStuInfoController {
     })
     public CommonResult updateMemberNameCouncillor(@Valid @RequestBody MemberNameUpdateDto memberNameUpdateDto) {
         stuInfoService.updateMemberName(memberNameUpdateDto);
+        return responseService.getSuccessResult();
+    }
+
+    /**
+     * 학생 정보 변경 - 성별 변경
+     * @param genderUpdateDto (receiverId, gender)
+     * @return CommonResult - SuccessResult
+     * @author 배태현
+     */
+    @PutMapping("/info/gender")
+    @ResponseStatus( HttpStatus.OK )
+    @ApiOperation(value = "성별 변경", notes = "성별 변경")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
+    public CommonResult updateGenderCouncillor(@Valid @RequestBody GenderUpdateDto genderUpdateDto) {
+        stuInfoService.updateGender(genderUpdateDto);
         return responseService.getSuccessResult();
     }
 

--- a/src/main/java/com/server/Dotori/domain/stu_info/controller/developer/DeveloperStuInfoController.java
+++ b/src/main/java/com/server/Dotori/domain/stu_info/controller/developer/DeveloperStuInfoController.java
@@ -1,5 +1,6 @@
 package com.server.Dotori.domain.stu_info.controller.developer;
 
+import com.server.Dotori.domain.stu_info.dto.GenderUpdateDto;
 import com.server.Dotori.domain.stu_info.dto.MemberNameUpdateDto;
 import com.server.Dotori.domain.stu_info.dto.RoleUpdateDto;
 import com.server.Dotori.domain.stu_info.dto.StuNumUpdateDto;
@@ -108,6 +109,24 @@ public class DeveloperStuInfoController {
     })
     public CommonResult updateMemberNameDeveloper(@Valid @RequestBody MemberNameUpdateDto memberNameUpdateDto) {
         stuInfoService.updateMemberName(memberNameUpdateDto);
+        return responseService.getSuccessResult();
+    }
+
+    /**
+     * 학생 정보 변경 - 성별 변경
+     * @param genderUpdateDto (receiverId, gender)
+     * @return CommonResult - SuccessResult
+     * @author 배태현
+     */
+    @PutMapping("/info/gender")
+    @ResponseStatus( HttpStatus.OK )
+    @ApiOperation(value = "성별 변경", notes = "성별 변경")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header"),
+            @ApiImplicitParam(name = "RefreshToken", value = "로그인 성공 후 refresh_token", required = false, dataType = "String", paramType = "header")
+    })
+    public CommonResult updateGenderDeveloper(@Valid @RequestBody GenderUpdateDto genderUpdateDto) {
+        stuInfoService.updateGender(genderUpdateDto);
         return responseService.getSuccessResult();
     }
 

--- a/src/main/java/com/server/Dotori/domain/stu_info/dto/GenderUpdateDto.java
+++ b/src/main/java/com/server/Dotori/domain/stu_info/dto/GenderUpdateDto.java
@@ -1,0 +1,13 @@
+package com.server.Dotori.domain.stu_info.dto;
+
+import com.server.Dotori.domain.member.enumType.Gender;
+import lombok.*;
+
+@Getter @Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED) @NoArgsConstructor
+public class GenderUpdateDto {
+
+    private Long receiverId;
+
+    private Gender gender;
+}

--- a/src/main/java/com/server/Dotori/domain/stu_info/dto/StudentInfoDto.java
+++ b/src/main/java/com/server/Dotori/domain/stu_info/dto/StudentInfoDto.java
@@ -1,5 +1,6 @@
 package com.server.Dotori.domain.stu_info.dto;
 
+import com.server.Dotori.domain.member.enumType.Gender;
 import com.server.Dotori.domain.member.enumType.Role;
 import com.server.Dotori.domain.member.enumType.SelfStudy;
 import lombok.AccessLevel;
@@ -18,4 +19,5 @@ public class StudentInfoDto {
     private String memberName;
     private List<Role> roles;
     private SelfStudy selfStudy;
+    private Gender gender;
 }

--- a/src/main/java/com/server/Dotori/domain/stu_info/service/Impl/StuInfoServiceImpl.java
+++ b/src/main/java/com/server/Dotori/domain/stu_info/service/Impl/StuInfoServiceImpl.java
@@ -31,7 +31,7 @@ public class StuInfoServiceImpl implements StuInfoService {
      * 학년반별로 조회한 학생들 List를 List Dto로 변경후 반환하는 서비스로직 (사감쌤, 개발자, 자치위원 사용가능)
      * @param id classId
      * @exception DotoriException (MEMBER_NOT_FOUND_BY_CLASS) 해당 반에 해당하는 학생들이 없을 때
-     * @return List - StudentInfoDto (id, stuNum, username, roles)
+     * @return List - StudentInfoDto (id, stuNum, username, roles, gender)
      * @author 배태현
      */
     @Override
@@ -45,7 +45,7 @@ public class StuInfoServiceImpl implements StuInfoService {
 
     /**
      * 전체 조회한 학생들 List를 List Dto로 변경후 반환하는 서비스로직 (사감쌤, 개발자, 자치위원 사용가능)
-     * @return List - StudentInfoDto (id, stuNum, username, roles)
+     * @return List - StudentInfoDto (id, stuNum, username, roles, gender)
      * @author 배태현
      */
     @Override
@@ -118,6 +118,12 @@ public class StuInfoServiceImpl implements StuInfoService {
 
     }
 
+    /**
+     * 학생의 성별을 변경시키는 서비스 로직 (사감쌤, 개발자, 자치위원 사용가능)
+     * @param genderUpdateDto (receiverId, gender)
+     * @exception DotoriException (MEMBER_NOT_FOUND) 해당 Id에 해당하는 유저를 찾을 수 없을 때
+     * @author 배태현
+     */
     @Override
     @Transactional
     public void updateGender(GenderUpdateDto genderUpdateDto) {

--- a/src/main/java/com/server/Dotori/domain/stu_info/service/Impl/StuInfoServiceImpl.java
+++ b/src/main/java/com/server/Dotori/domain/stu_info/service/Impl/StuInfoServiceImpl.java
@@ -1,10 +1,7 @@
 package com.server.Dotori.domain.stu_info.service.Impl;
 
 import com.server.Dotori.domain.member.Member;
-import com.server.Dotori.domain.stu_info.dto.MemberNameUpdateDto;
-import com.server.Dotori.domain.stu_info.dto.RoleUpdateDto;
-import com.server.Dotori.domain.stu_info.dto.StuNumUpdateDto;
-import com.server.Dotori.domain.stu_info.dto.StudentInfoDto;
+import com.server.Dotori.domain.stu_info.dto.*;
 import com.server.Dotori.domain.member.repository.member.MemberRepository;
 import com.server.Dotori.domain.stu_info.service.StuInfoService;
 import com.server.Dotori.global.exception.DotoriException;
@@ -119,6 +116,15 @@ public class StuInfoServiceImpl implements StuInfoService {
 
         findMember.updateMemberName(memberNameUpdateDto.getMemberName());
 
+    }
+
+    @Override
+    @Transactional
+    public void updateGender(GenderUpdateDto genderUpdateDto) {
+        Member member = memberRepository.findById(genderUpdateDto.getReceiverId())
+                .orElseThrow(() -> new DotoriException(MEMBER_NOT_FOUND));
+
+        member.updateMemberGender(genderUpdateDto.getGender());
     }
 
     /**

--- a/src/main/java/com/server/Dotori/domain/stu_info/service/StuInfoService.java
+++ b/src/main/java/com/server/Dotori/domain/stu_info/service/StuInfoService.java
@@ -1,9 +1,6 @@
 package com.server.Dotori.domain.stu_info.service;
 
-import com.server.Dotori.domain.stu_info.dto.MemberNameUpdateDto;
-import com.server.Dotori.domain.stu_info.dto.RoleUpdateDto;
-import com.server.Dotori.domain.stu_info.dto.StuNumUpdateDto;
-import com.server.Dotori.domain.stu_info.dto.StudentInfoDto;
+import com.server.Dotori.domain.stu_info.dto.*;
 
 import java.util.List;
 
@@ -18,6 +15,8 @@ public interface StuInfoService {
     void updateStuNum(StuNumUpdateDto stuNumUpdateDto);
 
     void updateMemberName(MemberNameUpdateDto memberNameUpdateDto);
+
+    void updateGender(GenderUpdateDto genderUpdateDto);
 
     List<StudentInfoDto> getStuInfoByMemberName(String memberName);
 }

--- a/src/test/java/com/server/Dotori/domain/self_study/service/SelfStudyServiceTest.java
+++ b/src/test/java/com/server/Dotori/domain/self_study/service/SelfStudyServiceTest.java
@@ -2,11 +2,10 @@ package com.server.Dotori.domain.self_study.service;
 
 import com.server.Dotori.domain.member.Member;
 import com.server.Dotori.domain.member.dto.MemberDto;
-import com.server.Dotori.domain.member.enumType.Gender;
-import com.server.Dotori.domain.self_study.dto.SelfStudyStudentsDto;
 import com.server.Dotori.domain.member.enumType.Role;
 import com.server.Dotori.domain.member.enumType.SelfStudy;
 import com.server.Dotori.domain.member.repository.member.MemberRepository;
+import com.server.Dotori.domain.self_study.dto.SelfStudyStudentsDto;
 import com.server.Dotori.domain.self_study.repository.SelfStudyRepository;
 import com.server.Dotori.global.exception.DotoriException;
 import com.server.Dotori.global.util.CurrentMemberUtil;
@@ -27,6 +26,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static com.server.Dotori.domain.member.enumType.Gender.MAN;
 import static com.server.Dotori.domain.member.enumType.Music.CAN;
 import static com.server.Dotori.domain.member.enumType.SelfStudy.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -55,7 +55,7 @@ class SelfStudyServiceTest {
                 .stuNum("2409")
                 .password("0809")
                 .email("s20032@gsm.hs.kr")
-                .gender(Gender.MAN)
+                .gender(MAN)
                 .build();
         memberRepository.save(
                 memberDto.toEntity(
@@ -135,9 +135,11 @@ class SelfStudyServiceTest {
 
         //then
         assertEquals(1, selfStudyStudents.size());
+        assertEquals(MAN, selfStudyStudents.get(0).getGender());
     }
 
     @Test
+    @DisplayName("자습을 신청한 순서대로 자습신청한 학생들 목록이 잘 조회 되나요 ?")
     public void getSelfStudyByCreateDate() {
         //given //when
         selfStudyService.requestSelfStudy(DayOfWeek.MONDAY, 20);
@@ -145,6 +147,7 @@ class SelfStudyServiceTest {
 
         //then
         assertEquals(1, students.size());
+        assertEquals(MAN, students.get(0).getGender());
     }
 
     @Test
@@ -156,6 +159,7 @@ class SelfStudyServiceTest {
 
         //then
         assertEquals(1, selfStudyStudentsByCategory.size());
+        assertEquals(MAN, selfStudyStudentsByCategory.get(0).getGender());
     }
 
     @Test
@@ -172,7 +176,7 @@ class SelfStudyServiceTest {
                         .music(CAN)
                         .selfStudy(APPLIED)
                         .point(0L)
-                        .gender(Gender.MAN)
+                        .gender(MAN)
                         .build()
         );
 
@@ -186,7 +190,7 @@ class SelfStudyServiceTest {
                         .music(CAN)
                         .selfStudy(CANT)
                         .point(0L)
-                        .gender(Gender.MAN)
+                        .gender(MAN)
                         .build()
         );
 
@@ -200,7 +204,7 @@ class SelfStudyServiceTest {
                         .music(CAN)
                         .selfStudy(SelfStudy.CAN)
                         .point(0L)
-                        .gender(Gender.MAN)
+                        .gender(MAN)
                         .build()
         );
 
@@ -263,13 +267,8 @@ class SelfStudyServiceTest {
     }
 
     @Test
-    @DisplayName("")
+    @DisplayName("자습신청 금지 때 회원을 찾을 수 없음 예외가 잘 터지나요 ?")
     public void banAndBanCancelSelfStudyExceptionTest() {
-        assertThrows(
-                DotoriException.class,
-                () -> selfStudyService.banSelfStudy(0L)
-        );
-
         assertThrows(
                 DotoriException.class,
                 () -> selfStudyService.banSelfStudy(0L)

--- a/src/test/java/com/server/Dotori/domain/stu_info/service/StuInfoServiceTest.java
+++ b/src/test/java/com/server/Dotori/domain/stu_info/service/StuInfoServiceTest.java
@@ -1,13 +1,9 @@
 package com.server.Dotori.domain.stu_info.service;
 
-import com.server.Dotori.domain.member.dto.*;
-import com.server.Dotori.domain.member.enumType.Gender;
-import com.server.Dotori.domain.stu_info.dto.MemberNameUpdateDto;
-import com.server.Dotori.domain.stu_info.dto.RoleUpdateDto;
-import com.server.Dotori.domain.stu_info.dto.StuNumUpdateDto;
-import com.server.Dotori.domain.stu_info.dto.StudentInfoDto;
+import com.server.Dotori.domain.member.dto.MemberDto;
 import com.server.Dotori.domain.member.enumType.Role;
 import com.server.Dotori.domain.member.repository.member.MemberRepository;
+import com.server.Dotori.domain.stu_info.dto.*;
 import com.server.Dotori.global.util.CurrentMemberUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -25,6 +21,8 @@ import javax.persistence.EntityManager;
 import java.util.Collections;
 import java.util.List;
 
+import static com.server.Dotori.domain.member.enumType.Gender.MAN;
+import static com.server.Dotori.domain.member.enumType.Gender.WOMAN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -47,7 +45,7 @@ class StuInfoServiceTest {
                 .stuNum("2409")
                 .password("0809")
                 .email("s20032@gsm.hs.kr")
-                .gender(Gender.MAN)
+                .gender(MAN)
                 .build();
         memberRepository.save(
                 memberDto.toEntity(
@@ -134,6 +132,21 @@ class StuInfoServiceTest {
 
         //then
         assertNotNull(memberRepository.findByEmail("s20032@gsm.hs.kr"));
+    }
+
+    @Test
+    @DisplayName("학생의 성별이 잘 변경되나요 ?")
+    public void updateGenderTest() {
+        //given //when
+        stuInfoService.updateGender(
+                GenderUpdateDto.builder()
+                        .receiverId(currentMemberUtil.getCurrentMember().getId())
+                        .gender(WOMAN)
+                        .build()
+        );
+
+        //then
+        assertEquals(WOMAN, memberRepository.findByEmail("s20032@gsm.hs.kr").get().getGender());
     }
 
     @Test


### PR DESCRIPTION
### 제가 한 일이에요 !
* 자습신청된 학생 목록 조회에서 학생의 성별도 반환되게 추가했습니다.
* 학생 정보 학생 목록 조회에서 학생의 성별도 반환되게 추가했습니다.
* 학생 정보에서 학생 성별을 변경하는 기능을 추가했습니다.