### PR TITLE
안마의자 상태 반환 api hotfix

### DIFF
--- a/src/main/java/com/server/Dotori/domain/massage/service/Impl/MassageServiceImpl.java
+++ b/src/main/java/com/server/Dotori/domain/massage/service/Impl/MassageServiceImpl.java
@@ -140,10 +140,9 @@ public class MassageServiceImpl implements MassageService {
         Map<String, String> map = new HashMap<>();
         map.put("status",currentMemberUtil.getCurrentMember().getMassage().toString());
         map.put("count", String.valueOf(massageRepository.count()));
-        if (currentMemberUtil.getCurrentMember().getMassageExpiredDate() == null) {
-            return map;
+        if (!(currentMemberUtil.getCurrentMember().getMassageExpiredDate() == null)) {
+            map.put("expiredTime", currentMemberUtil.getCurrentMember().getMassageExpiredDate().format(DateTimeFormatter.ofPattern("yyyyMMdd")));
         }
-        map.put("expiredTime", currentMemberUtil.getCurrentMember().getMassageExpiredDate().format(DateTimeFormatter.ofPattern("yyyyMMdd")));
         return map;
     }
 

--- a/src/main/java/com/server/Dotori/domain/massage/service/Impl/MassageServiceImpl.java
+++ b/src/main/java/com/server/Dotori/domain/massage/service/Impl/MassageServiceImpl.java
@@ -140,6 +140,9 @@ public class MassageServiceImpl implements MassageService {
         Map<String, String> map = new HashMap<>();
         map.put("status",currentMemberUtil.getCurrentMember().getMassage().toString());
         map.put("count", String.valueOf(massageRepository.count()));
+        if (currentMemberUtil.getCurrentMember().getMassageExpiredDate() == null) {
+            return map;
+        }
         map.put("expiredTime", currentMemberUtil.getCurrentMember().getMassageExpiredDate().format(DateTimeFormatter.ofPattern("yyyyMMdd")));
         return map;
     }


### PR DESCRIPTION
* 해결방식
  기존 로직의 경우 신청하지 않은 학생들의 만료기간은 null이기 때문에 string 형식의 변환과정에서 문제가 일어남
  그래서 만료기간이 null이 아닌 학생들만 map에 추가로 만료기간을 넣어서 보냄