### PR TITLE
Multi thread 환경에서 자습신청을 했을 때 51명이 신청되는 동시성 이슈 해결

### DIFF
--- a/src/main/java/com/server/Dotori/domain/self_study/repository/SelfStudyRepository.java
+++ b/src/main/java/com/server/Dotori/domain/self_study/repository/SelfStudyRepository.java
@@ -5,12 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
-import static javax.persistence.LockModeType.PESSIMISTIC_READ;
+import javax.persistence.LockModeType;
 
 @Repository
 public interface SelfStudyRepository extends JpaRepository<SelfStudy, Long>, SelfStudyRepositoryCustom {
     void deleteByMemberId(Long id);
 
-    @Lock(PESSIMISTIC_READ)
+    @Lock(LockModeType.PESSIMISTIC_READ)
     long count();
 }

--- a/src/main/java/com/server/Dotori/domain/self_study/repository/SelfStudyRepository.java
+++ b/src/main/java/com/server/Dotori/domain/self_study/repository/SelfStudyRepository.java
@@ -2,9 +2,15 @@ package com.server.Dotori.domain.self_study.repository;
 
 import com.server.Dotori.domain.self_study.SelfStudy;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
+
+import static javax.persistence.LockModeType.PESSIMISTIC_READ;
 
 @Repository
 public interface SelfStudyRepository extends JpaRepository<SelfStudy, Long>, SelfStudyRepositoryCustom {
     void deleteByMemberId(Long id);
+
+    @Lock(PESSIMISTIC_READ)
+    long count();
 }

--- a/src/main/java/com/server/Dotori/domain/self_study/service/Impl/SelfStudyServiceImpl.java
+++ b/src/main/java/com/server/Dotori/domain/self_study/service/Impl/SelfStudyServiceImpl.java
@@ -210,6 +210,7 @@ public class SelfStudyServiceImpl implements SelfStudyService {
      * @param selfStudy selfStudyStatus
      * @return boolean
      * @exception DotoriException (SELF_STUDY_ALREADY) 자습신청 상태가 CAN(가능)이 아닐 때 (자습신청을 할 수 없는 상태)
+     * @exception DotoriException (SELF_STUDY_CANT_CANCEL) 자습신청 상태가 APPLIED(신청됨)이 아닐 때 (자습신청을 취소할 수 없는 상태)
      * @author 배태현
      */
     private boolean isVerifiedSelfStudy(com.server.Dotori.domain.member.enumType.SelfStudy selfStudy, ErrorCode errorCode) {


### PR DESCRIPTION
### 제가 한 일이에요 !
* #342 이슈 해결
Multi thread 환경에서 자습신청을 했을 때 51명이 신청되는 동시성 이슈 해결 (**count query에 비관적 Lock을 적용해 해결**했어요) 
    > [참고자료](https://stackoverflow.com/questions/35964692/jpa-optimistic-locking-vs-synchronized-java-method)입니다 !
* @jyeonjyan님과 pair programming을 통해 자습 신청/취소 서비스 로직 **예외처리 부분**을 
캡슐화 된 메서드에서 처리하도록 리팩토링 했습니다.