### PR TITLE
MultiThread 동시성 문제 설계상 비관적 Lock이 적용되지 않아 synchronized로 변경

### DIFF
--- a/src/main/java/com/server/Dotori/domain/self_study/repository/SelfStudyRepository.java
+++ b/src/main/java/com/server/Dotori/domain/self_study/repository/SelfStudyRepository.java
@@ -2,15 +2,9 @@ package com.server.Dotori.domain.self_study.repository;
 
 import com.server.Dotori.domain.self_study.SelfStudy;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
-
-import javax.persistence.LockModeType;
 
 @Repository
 public interface SelfStudyRepository extends JpaRepository<SelfStudy, Long>, SelfStudyRepositoryCustom {
     void deleteByMemberId(Long id);
-
-    @Lock(LockModeType.PESSIMISTIC_READ)
-    long count();
 }

--- a/src/main/java/com/server/Dotori/domain/self_study/service/Impl/SelfStudyServiceImpl.java
+++ b/src/main/java/com/server/Dotori/domain/self_study/service/Impl/SelfStudyServiceImpl.java
@@ -45,7 +45,7 @@ public class SelfStudyServiceImpl implements SelfStudyService {
      */
     @Override
     @Transactional
-    public void requestSelfStudy(DayOfWeek dayOfWeek, int hour) {
+    public synchronized void requestSelfStudy(DayOfWeek dayOfWeek, int hour) {
         validDayOfWeekAndHour(dayOfWeek, hour, SELF_STUDY_CANT_REQUEST_DATE, SELF_STUDY_CANT_REQUEST_TIME);
 
         Member currentMember = currentMemberUtil.getCurrentMember();

--- a/src/test/java/com/server/Dotori/domain/self_study/service/SelfStudyServiceTest.java
+++ b/src/test/java/com/server/Dotori/domain/self_study/service/SelfStudyServiceTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 @TestMethodOrder(OrderAnnotation.class)
 class SelfStudyServiceTest {
 
-    private int THREAD_CNT = 60;
+    private int THREAD_CNT = 100;
     private ExecutorService ex = Executors.newFixedThreadPool(THREAD_CNT);
     private CountDownLatch latch = new CountDownLatch(THREAD_CNT);
 
@@ -98,9 +98,10 @@ class SelfStudyServiceTest {
     }
 
     @Test
+    @Disabled
     @DisplayName("자습신청 동시성 테스트")
     public void requestSelfStudyMultiThreadTest() throws InterruptedException {
-        for (int i = 0; i < 60; i++) {
+        for (int i = 0; i < THREAD_CNT; i++) {
             ex.execute(() -> {
                 selfStudyService.requestSelfStudy(DayOfWeek.MONDAY, 20);
                 latch.countDown();
@@ -109,7 +110,9 @@ class SelfStudyServiceTest {
 
         latch.await();
 
+        long count = selfStudyRepository.count();
 
+        System.out.println("count = " + count);
     }
 
     @Test


### PR DESCRIPTION
### 제가 한 일이에요 !
* #342 

    > Multi Thread 환경에서 테스트 코드를 작성하던 중 **Multi Thread 환경에서 동시성 문제가 해결되지 않은 것을 인지**했습니다.

* MultiThread 환경에서 테스트 코드 작성 후 disable 
    > 설계상 service 로직 일부분을 주석처리 하지 않으면 테스트가 가능한 구조가 아님 (**나중에 개선 필요**)
(캡슐화 한 private method, currentMember 등등 때문)
    >
    > **나중에 mockito를 이용하더라도 테스트에 지장**이 있기 때문에 
**specification 패턴을 적용**하여 서비스 클래스에서 캡슐화 된 private 메서드를 분리하는 등 
의존관계를 분리하여 관리하면 테스트도 한층 수월해질 뿐더러 코드 품질도 개선될 것 같습니다.
* Multi Thread 동시성 문제 설계상 비관적 Lock이 적용되지 않아 `synchronized`로 변경했습니다.
    > `synchronized`를 사용함으로써 **병렬성, 즉 포퍼먼스 저하(성능 저하)가 발생**하지만, 
저희의 설계상 비관적 Lock이 적용되지 않아 동시성 문제가 해결되지 않은 상태였습니다.
**count query는 비관적 Lock(for update)이 적용되지 않습니다.**
(비관적 lock은 Entity field에 대한 데이터를 thread마다 동기화거나 thread의 접근(조회)을 제한할 수 있음, 
JPQL을 이용해서 **강제로 적용하더라도 적합한 쿼리가 아니라며 예외가 발생**합니다.)
    > 
    > 나중에 저희가 시간적 여유가 생기면 해결하거나(현재 3학년들은 취업에 집중 중), 
서비스를 물려받을 후배들에게 잘 설명해주어 레거시를 청산할 때
**자습신청 feature를 재설계하여 비관적 Lock을 적용하여 해결하면 좋을 것 같습니다. (성능까지 챙길 수 있기 때문)**
    > 
    > 현재는 이 상태로 배포한 뒤 월요일에 모니터링 하며 성능을 테스트 해봐야할 것 같습니다. 
(`synchronized` 한번 사용한다고 **굉장한 성능 저하가 있는건 아닙니다.**)

새벽까지 정보를 찾아보았지만 재설계 또는 `synchronized` 외엔 다른 해결방법을 찾지 못해 
결국엔 적용하기 싫었던 `synchronized` 적용 후 올립니다..

@TeMlN 추가로 안마의자도 적용해야 될 것으로 보입니다.