### PR TITLE
안마의자 전체적인 리팩토링 및 안마의자 신청 취소 로직 부분변경

### DIFF
--- a/src/main/java/com/server/Dotori/domain/massage/controller/councillor/CouncillorMassageController.java
+++ b/src/main/java/com/server/Dotori/domain/massage/controller/councillor/CouncillorMassageController.java
@@ -54,7 +54,7 @@ public class CouncillorMassageController {
     })
     public CommonResult cancelMassageCouncillor() {
         LocalDateTime currentTime = LocalDateTime.now();
-        massageService.cancelMassage(currentTime.getDayOfWeek(), currentTime.getHour(), currentTime.getMinute());
+        massageService.cancelMassage(currentTime.getHour(), currentTime.getMinute());
         return responseService.getSuccessResult();
     }
 

--- a/src/main/java/com/server/Dotori/domain/massage/controller/developer/DeveloperMassageController.java
+++ b/src/main/java/com/server/Dotori/domain/massage/controller/developer/DeveloperMassageController.java
@@ -54,7 +54,7 @@ public class DeveloperMassageController {
     })
     public CommonResult cancelMassageDeveloper() {
         LocalDateTime currentTime = LocalDateTime.now();
-        massageService.cancelMassage(currentTime.getDayOfWeek(), currentTime.getHour(), currentTime.getMinute());
+        massageService.cancelMassage(currentTime.getHour(), currentTime.getMinute());
         return responseService.getSuccessResult();
     }
 

--- a/src/main/java/com/server/Dotori/domain/massage/controller/member/MemberMassageController.java
+++ b/src/main/java/com/server/Dotori/domain/massage/controller/member/MemberMassageController.java
@@ -54,7 +54,7 @@ public class MemberMassageController {
     })
     public CommonResult cancelMassageMember() {
         LocalDateTime currentTime = LocalDateTime.now();
-        massageService.cancelMassage(currentTime.getDayOfWeek(), currentTime.getHour(), currentTime.getMinute());
+        massageService.cancelMassage(currentTime.getHour(), currentTime.getMinute());
         return responseService.getSuccessResult();
     }
 

--- a/src/main/java/com/server/Dotori/domain/massage/service/Impl/MassageServiceImpl.java
+++ b/src/main/java/com/server/Dotori/domain/massage/service/Impl/MassageServiceImpl.java
@@ -32,8 +32,9 @@ public class MassageServiceImpl implements MassageService {
 
     /**
      * 안마의자를 신청하는 로직
-     * 5명이 신청가능, 안마의자 신청 상태가 'CAN'일때만 신청가능, 금토일은 신청 불가능
-     * 주중 금토일을 제외한 20시 20분 ~ 21시 사이에 신청가능
+     * timeValidateRequestMassage(dayOfWeek, hour, min): 안마의자 신청을 할 수 있는 시간과 요일인지 검증
+     * countValidate(count): 안마의자를 신청한 학생이 5명 미만인지 검증
+     * massageStatusValidate(currentMember, MassageStatus.CAN): 안마의자 신청 상태가 CAN인지 검증
      * 안마의자 신청시 상태가 'CAN'에서 'APPLIED'로 변경
      * @param dayOfWeek 현재 요일
      * @param hour 현재 시
@@ -61,13 +62,14 @@ public class MassageServiceImpl implements MassageService {
         } catch (DataIntegrityViolationException e) {
             throw new DotoriException(ErrorCode.MASSAGE_ALREADY);
         }
+        currentMember.updateMassage(MassageStatus.APPLIED);
         log.info("Current MassageRequest Student Count is {}", count+1);
     }
 
     /**
      * 안마의자 신청 취소하는 로직
-     * 5명이 신청가능, 안마의자 신청 상태가 'APPLIED'일때만 취소가능, 금토일은 신청 불가능
-     * 주중 금토일을 제외한 20시 20분 ~ 21시 사이에 취소가능
+     * timeValidateRequestMassage(hour, min): 안마의자 신청을 할 수 있는 시간과 요일인지 검증
+     * massageStatusValidate(currentMember, MassageStatus.APPLIED): 안마의자 신청 상태가 APPLIED인지 검증
      * 안마의자 신청 취소시 상태가 "APPLIED"에서 "CANT"로 변경
      * 안마의자 신청을 취소한 학생은 MASSAGE 테이블에서 삭제
      * @param hour 현재 시
@@ -86,8 +88,8 @@ public class MassageServiceImpl implements MassageService {
         massageStatusValidate(currentMember, MassageStatus.APPLIED);
         long count = massageRepository.count();
 
-        currentMember.updateMassage(MassageStatus.CANT);
         massageRepository.deleteByMemberId(currentMember.getId());
+        currentMember.updateMassage(MassageStatus.CANT);
 
         log.info("Current MassageRequest Student Count is {}", count-1);
     }

--- a/src/main/java/com/server/Dotori/domain/massage/service/Impl/MassageServiceImpl.java
+++ b/src/main/java/com/server/Dotori/domain/massage/service/Impl/MassageServiceImpl.java
@@ -74,8 +74,7 @@ public class MassageServiceImpl implements MassageService {
      * 안마의자 신청을 취소한 학생은 MASSAGE 테이블에서 삭제
      * @param hour 현재 시
      * @param min 현재 분
-     * @exception DotoriException (MASSAGE_CANT_REQUEST_THIS_DATE) 안마의자 신청을 하실 수 없는 요일입니다.
-     * @exception DotoriException (MASSAGE_CANT_REQUEST_THIS_TIME) 안마의자 신청은 오후 8시부터 오후 10시까지만 신청이 가능합니다.
+     * @exception DotoriException (MASSAGE_CANT_CANCEL_THIS_TIME) 안마의자 신천 취소는 오후 8시부터 오후 10시까지만 신청 취소가 가능합니다.
      * @exception DotoriException (MASSAGE_CANT_CANCEL_REQUEST) 안마의자 신청을 취소할 수 있는 상태가 아닙니다.
      * @author 김태민
      */

--- a/src/main/java/com/server/Dotori/domain/massage/service/MassageService.java
+++ b/src/main/java/com/server/Dotori/domain/massage/service/MassageService.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 public interface MassageService {
     void requestMassage(DayOfWeek dayOfWeek, int hour, int min);
-    void cancelMassage(DayOfWeek dayOfWeek, int hour, int min);
+    void cancelMassage(int hour, int min);
     void updateMassageStatus();
     List<MassageStudentsDto> getMassageStudents();
     Map<String, String> getMassageInfo();

--- a/src/main/java/com/server/Dotori/global/exception/ErrorCode.java
+++ b/src/main/java/com/server/Dotori/global/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     MASSAGE_OVER(HttpStatus.CONFLICT, "안마의자 신청 인원이 5명을 초과 하였습니다."),
     MASSAGE_CANT_REQUEST_THIS_TIME(HttpStatus.ACCEPTED, "안마의자 신청은 오후 8시부터 오후 10시까지만 신청이 가능합니다."),
     MASSAGE_CANT_REQUEST_THIS_DATE(HttpStatus.ACCEPTED, "안마의자 신청을 하실 수 없는 요일입니다."),
+    MASSAGE_CANT_CANCEL_THIS_TIME(HttpStatus.ACCEPTED, "안마의자 신청 취소는 오후 8시부터 오후 10시까지만 신청이 가능합니다."),
     MASSAGE_ANYONE_NOT_REQUEST(HttpStatus.ACCEPTED, "안마의자를 신청한 학생이 없습니다"),
     MASSAGE_CANT_CANCEL_REQUEST(HttpStatus.ACCEPTED, "안마의자 신청을 취소할 수 있는 상태가 아닙니다."),
 

--- a/src/main/java/com/server/Dotori/global/exception/ErrorCode.java
+++ b/src/main/java/com/server/Dotori/global/exception/ErrorCode.java
@@ -17,7 +17,7 @@ public enum ErrorCode {
     MASSAGE_OVER(HttpStatus.CONFLICT, "안마의자 신청 인원이 5명을 초과 하였습니다."),
     MASSAGE_CANT_REQUEST_THIS_TIME(HttpStatus.ACCEPTED, "안마의자 신청은 오후 8시부터 오후 10시까지만 신청이 가능합니다."),
     MASSAGE_CANT_REQUEST_THIS_DATE(HttpStatus.ACCEPTED, "안마의자 신청을 하실 수 없는 요일입니다."),
-    MASSAGE_CANT_CANCEL_THIS_TIME(HttpStatus.ACCEPTED, "안마의자 신청 취소는 오후 8시부터 오후 10시까지만 신청이 가능합니다."),
+    MASSAGE_CANT_CANCEL_THIS_TIME(HttpStatus.ACCEPTED, "안마의자 신청 취소는 오후 8시부터 오후 10시까지만 신청 취소가 가능합니다."),
     MASSAGE_ANYONE_NOT_REQUEST(HttpStatus.ACCEPTED, "안마의자를 신청한 학생이 없습니다"),
     MASSAGE_CANT_CANCEL_REQUEST(HttpStatus.ACCEPTED, "안마의자 신청을 취소할 수 있는 상태가 아닙니다."),
 

--- a/src/test/java/com/server/Dotori/domain/massage/service/MassageStatusServiceTest.java
+++ b/src/test/java/com/server/Dotori/domain/massage/service/MassageStatusServiceTest.java
@@ -97,7 +97,7 @@ public class MassageStatusServiceTest {
     @DisplayName("안마의자 신청 취소가 잘 되는지 검증")
     public void cancelMassageTest() {
         massageService.requestMassage(DayOfWeek.THURSDAY,20,30);
-        massageService.cancelMassage(DayOfWeek.THURSDAY, 20, 31);
+        massageService.cancelMassage(20, 31);
 
         assertEquals(MassageStatus.CANT, currentMemberUtil.getCurrentMember().getMassageStatus());
         assertEquals(0, massageRepository.count());


### PR DESCRIPTION
안마의자 신청, 취소 부분을 세부로직을 private method로 빼내고 try catch state에선 Massage테이블에 save하는 로직만 수행하도록 하였습니다 catch는 DataIntegrityViolationException만 핸들링 하도록 하였습니다. 

ErrorCode에 `MASSAGE_CANT_CANCEL_THIS_TIME` 안마의자 신청 취소는 오후 8시부터 오후 10시까지만 신청 취소가 가능합니다.
를 추가하였습니다.

안마의자 신청 취소 로직이 조금 바뀌었습니다,
안마의자의 신청상태가 APPLED인지 검증하고
시간"만" 검증하도록 하였습니다 (요일 제외)

자세한 사항은 코드내 주석을 확인해주세요.