### PR TITLE
로그 변경

### DIFF
--- a/src/main/java/com/server/Dotori/global/config/interceptor/Interceptor.java
+++ b/src/main/java/com/server/Dotori/global/config/interceptor/Interceptor.java
@@ -1,0 +1,30 @@
+package com.server.Dotori.global.config.interceptor;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Log4j2
+@Component
+public class Interceptor extends HandlerInterceptorAdapter {
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        log.info("[Request] HTTP Method : '{}', uri : '{}'", request.getMethod(), request.getRequestURI(), response.getStatus());
+        return super.preHandle(request, response, handler);
+    }
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
+        log.info("[Response] method : '{}', uri : '{}', code : '{}'", request.getMethod(), request.getRequestURI(), response.getStatus());
+        super.postHandle(request, response, handler, modelAndView);
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+        super.afterCompletion(request, response, handler, ex);
+    }
+}

--- a/src/main/java/com/server/Dotori/global/config/web/WebConfig.java
+++ b/src/main/java/com/server/Dotori/global/config/web/WebConfig.java
@@ -4,21 +4,28 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.server.Dotori.global.config.interceptor.Interceptor;
 import com.server.Dotori.global.config.xss.HTMLCharacterEscapes;
 import io.swagger.models.HttpMethod;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
 
 import static com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS;
 
+@RequiredArgsConstructor
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    private final Interceptor interceptor;
+
     @Override //CORS 설정
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
@@ -37,6 +44,16 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
         converters.add(htmlEscapingConverter());
+    }
+
+    /**
+     *  매 요청마다 request 와 response 를 체크하는 인터셉터 등록
+     * @author 노경준
+     */
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(interceptor)
+                .addPathPatterns("/**");
     }
 
     /**

--- a/src/main/java/com/server/Dotori/global/exception/DotoriException.java
+++ b/src/main/java/com/server/Dotori/global/exception/DotoriException.java
@@ -1,11 +1,16 @@
 package com.server.Dotori.global.exception;
 
-import lombok.AllArgsConstructor;
+import com.server.Dotori.global.util.CurrentMemberUtil;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class DotoriException extends RuntimeException{
 
     private final ErrorCode errorCode;
+    private final String errorBy;
+
+    public DotoriException(ErrorCode errorCode){
+        this.errorCode = errorCode;
+        this.errorBy = CurrentMemberUtil.getMemberName();
+    }
 }

--- a/src/main/java/com/server/Dotori/global/exception/handler/DotoriExceptionHandler.java
+++ b/src/main/java/com/server/Dotori/global/exception/handler/DotoriExceptionHandler.java
@@ -17,7 +17,7 @@ public class DotoriExceptionHandler {
 
     @ExceptionHandler(value = {DotoriException.class})
     public ResponseEntity<ErrorResponse> handleDotoriException(DotoriException e) {
-        log.error("handleDotoriException throw DotoriException : {}", e.getErrorCode());
+        log.info("code : '{}', by : '{}'", e.getErrorCode(), e.getErrorBy());
         return ErrorResponse.toResponseEntity(e.getErrorCode());
     }
 

--- a/src/main/java/com/server/Dotori/global/security/SecurityConfig.java
+++ b/src/main/java/com/server/Dotori/global/security/SecurityConfig.java
@@ -10,7 +10,6 @@ import com.server.Dotori.global.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
@@ -81,7 +80,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/h2-console/**/**").permitAll()
 
                 // Disallow everything else..
-                .anyRequest().authenticated();
+                .anyRequest().permitAll();
 
         http.exceptionHandling()
                 .accessDeniedHandler(new CustomAccessDeniedHandler())

--- a/src/main/java/com/server/Dotori/global/util/CurrentMemberUtil.java
+++ b/src/main/java/com/server/Dotori/global/util/CurrentMemberUtil.java
@@ -16,8 +16,19 @@ public class CurrentMemberUtil {
 
     private final MemberRepository memberRepository;
 
+    public static String getMemberName(){
+        String memberName;
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if(principal instanceof UserDetails) {
+            memberName = ((Member) principal).getMemberName();
+        } else{
+            memberName = principal.toString();
+        }
+        return memberName;
+    }
+
     public static String getCurrentEmail(){
-        String email = null;
+        String email;
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         if(principal instanceof UserDetails) {
             email = ((Member) principal).getEmail();
@@ -28,7 +39,7 @@ public class CurrentMemberUtil {
     }
 
     public Member getCurrentMember() {
-        String email = null;
+        String email;
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         if(principal instanceof UserDetails) {
             email = ((Member) principal).getEmail();

--- a/src/test/java/com/server/Dotori/domain/rule/service/RuleServiceTest.java
+++ b/src/test/java/com/server/Dotori/domain/rule/service/RuleServiceTest.java
@@ -2,6 +2,7 @@ package com.server.Dotori.domain.rule.service;
 
 import com.server.Dotori.domain.member.dto.MemberDto;
 import com.server.Dotori.domain.member.enumType.Gender;
+import com.server.Dotori.domain.member.enumType.Role;
 import com.server.Dotori.domain.member.repository.member.MemberRepository;
 import com.server.Dotori.domain.rule.dto.RuleGrantDto;
 import com.server.Dotori.domain.rule.dto.RulesCntAndDatesDto;
@@ -11,6 +12,10 @@ import com.server.Dotori.global.exception.DotoriException;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,6 +54,14 @@ public class RuleServiceTest {
                         passwordEncoder.encode(memberDto1.getPassword())
                 )
         );
+
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
+                memberDto1.getEmail(),
+                memberDto1.getPassword(),
+                List.of(new SimpleGrantedAuthority(Role.ROLE_ADMIN.name())));
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(token);
+        System.out.println(context);
 
         MemberDto memberDto2 = MemberDto.builder()
                 .memberName("송시현")


### PR DESCRIPTION
### 제가 한 일은요!!
요즘 로그로 인한 이슈가 많아져서 로그에 큰 변화를 주었습니다.
1. **요청이 들어왔을때, 응답할때** 로그를 남길 수 있도록 변경했습니다. ( **인터셉터**를 추가했습니다. )
> 앞으로 prod 서버는 이런식으로 로깅될 예정입니다.
<img width="1409" alt="2022-05-11_10-58-42" src="https://user-images.githubusercontent.com/68670670/167753600-35a03c89-2b40-4dd8-ad53-6950594f32cc.png">

3. **의도된 익셉션(DotoriException) 로그 레벨을 error 에서 info 로 변경**했습니다.
> error 로그레벨은 의도하지 않은 예외를 로깅할때 사용됩니다. 고로 저희 DotoriException 은 info 레벨을 사용하는것이 옳습니다.
>
> https://blog.lulab.net/programmer/what-should-i-log-with-an-intention-method-and-level/
> 위 블로그를 참고하시면 로그레벨의 기준을 확인하실 수 있습니다. 

4. 이제 **의도된 에러를 반환할 때 누가 터뜨렸는지 확인**할 수 있습니다.
> 기존의 반환되는 에러를 확인하면 누가 어떻게 터뜨렸는지 알 수 없다고 판단하여 추가했습니다.

5. SecurityConfig **anyRequest 의 `.authenticated();` 를 `.permitAll();` 로 변경**했습니다.
> 이미 위에 권한별 처리가 되어있기때문에 `./permitAll();` 로 변경을 하여 **404 에러**를 띄울 수 있도록 했습니다. 
> **`.authenticated` 를 사용했을 경우 401 계속 반환**되기때문에, **404 를 띄워주는게 올바르다고 판단되어 변경**했습니다.

### 추가 코멘트 1
**로그 부분에 있어서는 점진적으로 상황을 봐가면서 변경해야할 것으로 판단되어 작업사항을 한번에 커밋하지 않았습니다.**
- 콘솔에 개편된 로그를 띄울 수 있도록 변경 ( 현재 커밋사항 )
- 파일에 로그를 남길 수 있도록 변경 ( 다음 커밋사항 )   

위 순서대로 커밋 될 예정이며 이러한 이유는 원래 sql 로그가 prod 서버에 계속되어 로깅되고 있어서
하루에 2.4G 라는 수치가 나왔는데,
오늘 sql 로깅을 제외시켜서 하루정도 나오는 용량을 체크하여
주말에 하루 평균 로그파일 용량을 계산한 후
얼마나 저장할 수 있을지 알아보고 난 후 피알 올리겠습니다.


### 추가 코멘트 2
로깅은 가독성이 중요하다고 생각됩니다. 
제 나름대로 가독성을 생각하여 메세지를 커스텀 했지만 
다른 사람눈에는 그러지 않을 수 있으니 위 첨부된 사진을 보시고 변경 되었으면 하는 부분이 있으면 코멘트 부탁드리겠습니다.
