### PR TITLE
자습신청 feature JPA 비관적 Lock 적용

### DIFF
--- a/src/main/java/com/server/Dotori/domain/member/repository/member/MemberRepositoryCustom.java
+++ b/src/main/java/com/server/Dotori/domain/member/repository/member/MemberRepositoryCustom.java
@@ -4,16 +4,11 @@ import com.server.Dotori.domain.main_page.dto.GetProfileDto;
 import com.server.Dotori.domain.massage.dto.MassageStudentsDto;
 import com.server.Dotori.domain.member.Member;
 import com.server.Dotori.domain.point.dto.GetAboutPointDto;
-import com.server.Dotori.domain.self_study.dto.SelfStudyStudentsDto;
 import com.server.Dotori.domain.rule.dto.FindStusDto;
 
 import java.util.List;
 
 public interface MemberRepositoryCustom {
-
-    List<SelfStudyStudentsDto> findBySelfStudyAPLLIED();
-
-    List<SelfStudyStudentsDto> findBySelfStudyCategory(Long id);
 
     void updateSelfStudyStatus();
 

--- a/src/main/java/com/server/Dotori/domain/member/repository/member/MemberRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/domain/member/repository/member/MemberRepositoryImpl.java
@@ -9,7 +9,6 @@ import com.server.Dotori.domain.member.enumType.MassageStatus;
 import com.server.Dotori.domain.member.enumType.SelfStudyStatus;
 import com.server.Dotori.domain.point.dto.GetAboutPointDto;
 import com.server.Dotori.domain.rule.dto.FindStusDto;
-import com.server.Dotori.domain.self_study.dto.SelfStudyStudentsDto;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDate;
@@ -24,51 +23,6 @@ import static com.server.Dotori.domain.member.QMember.member;
 public class MemberRepositoryImpl implements MemberRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
-
-    /**
-     * 자습신청 상태가 '신청됨' 상태인 회원들을 학번별로 오름순으로 조회하는 query
-     * @return List - SelfStudyStudentsDto (id, stuNum, username)
-     * @author 배태현
-     */
-    @Override
-    public List<SelfStudyStudentsDto> findBySelfStudyAPLLIED() {
-        return queryFactory.from(member)
-                .select(Projections.fields(SelfStudyStudentsDto.class,
-                        member.id,
-                        member.stuNum,
-                        member.memberName,
-                        member.gender
-                        )
-                ).where(
-                        member.selfStudyStatus.eq(SelfStudyStatus.APPLIED)
-                )
-                .orderBy(member.stuNum.asc())
-                .fetch();
-    }
-
-    /**
-     * 학년반별로 자습신청 상태가 '신청됨' 인 회원을 조회하는 query
-     * @param id classId
-     * @return List - SelfStudyStudentsDto (id, stuNum, username)
-     * @author 배태현
-     */
-    @Override
-    public List<SelfStudyStudentsDto> findBySelfStudyCategory(Long id) {
-        return queryFactory.from(member)
-                .select(Projections.fields(SelfStudyStudentsDto.class,
-                        member.id,
-                        member.stuNum,
-                        member.memberName,
-                        member.gender
-                        )
-                )
-                .where(
-                        member.selfStudyStatus.eq(SelfStudyStatus.APPLIED)
-                        .and(member.stuNum.like(id+"%"))
-                )
-                .orderBy(member.stuNum.asc())
-                .fetch();
-    }
 
     /**
      * 자습신청 상태가 '신청됨', '취소' 상태인 회원의 자습신청 상태를 '가능'으로 update하는 쿼리

--- a/src/main/java/com/server/Dotori/domain/self_study/SelfStudyCount.java
+++ b/src/main/java/com/server/Dotori/domain/self_study/SelfStudyCount.java
@@ -1,0 +1,37 @@
+package com.server.Dotori.domain.self_study;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity @Table(name="SelfStudyCount")
+@Builder @Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SelfStudyCount {
+
+    @Id
+    @Column(name = "selfStudyCount_id")
+    private Long id;
+
+    @Column(name = "selfStudyCount_count")
+    private Long count;
+
+    public void addCount() {
+        this.count++;
+    }
+
+    public void removeCount() {
+        this.count--;
+    }
+
+    public void updateCount(Long count) {
+        this.count = count != null ? count : this.count;
+    }
+}

--- a/src/main/java/com/server/Dotori/domain/self_study/dev/SelfStudyCountConfig.java
+++ b/src/main/java/com/server/Dotori/domain/self_study/dev/SelfStudyCountConfig.java
@@ -1,0 +1,32 @@
+package com.server.Dotori.domain.self_study.dev;
+
+import com.server.Dotori.domain.self_study.SelfStudyCount;
+import com.server.Dotori.domain.self_study.repository.SelfStudyCountRepository;
+import com.server.Dotori.domain.self_study.repository.SelfStudyRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SelfStudyCountConfig {
+
+    private final SelfStudyRepository selfStudyRepository;
+    private final SelfStudyCountRepository selfStudyCountRepository;
+
+    @PostConstruct
+    private void selfStudyCountEntitySetting() {
+        selfStudyCountRepository.deleteAll();
+        selfStudyCountRepository.save(
+                SelfStudyCount.builder()
+                        .id(1L)
+                        .count(selfStudyRepository.count())
+                        .build()
+        );
+
+        log.info("========== SelfStudyCount Setting Success ==========");
+    }
+}

--- a/src/main/java/com/server/Dotori/domain/self_study/repository/SelfStudyCountRepository.java
+++ b/src/main/java/com/server/Dotori/domain/self_study/repository/SelfStudyCountRepository.java
@@ -1,0 +1,15 @@
+package com.server.Dotori.domain.self_study.repository;
+
+import com.server.Dotori.domain.self_study.SelfStudyCount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.LockModeType;
+
+@Repository
+public interface SelfStudyCountRepository extends JpaRepository<SelfStudyCount, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    SelfStudyCount findSelfStudyCountById(Long id);
+}

--- a/src/main/java/com/server/Dotori/domain/self_study/repository/SelfStudyRepositoryCustom.java
+++ b/src/main/java/com/server/Dotori/domain/self_study/repository/SelfStudyRepositoryCustom.java
@@ -9,4 +9,6 @@ public interface SelfStudyRepositoryCustom {
     List<SelfStudyStudentsDto> findByCreateDate();
 
     List<SelfStudyStudentsDto> findByMemberName(String memberName);
+
+    List<SelfStudyStudentsDto> findBySelfStudyCategory(Long id);
 }

--- a/src/main/java/com/server/Dotori/domain/self_study/repository/SelfStudyRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/domain/self_study/repository/SelfStudyRepositoryImpl.java
@@ -25,9 +25,6 @@ public class SelfStudyRepositoryImpl implements SelfStudyRepositoryCustom {
                         selfStudy.member.gender
                         )
                 )
-//                .where(
-//                        selfStudy.member.selfStudyStatus.eq(SelfStudyStatus.APPLIED)
-//                )
                 .innerJoin(selfStudy.member, member)
                 .orderBy(selfStudy.createdDate.asc())
                 .fetch();
@@ -43,12 +40,30 @@ public class SelfStudyRepositoryImpl implements SelfStudyRepositoryCustom {
                         selfStudy.member.gender
                         )
                 )
-                .where(
-//                        selfStudy.member.selfStudyStatus.eq(SelfStudyStatus.APPLIED)
-//                        .and(selfStudy.member.memberName.like("%" + memberName + "%"))
-                    selfStudy.member.memberName.like("%" + memberName + "%")
-                )
+                .where(selfStudy.member.memberName.like("%" + memberName + "%"))
                 .innerJoin(selfStudy.member, member)
+                .fetch();
+    }
+
+    /**
+     * 학년반별로 자습신청 된 회원을 조회하는 query
+     * @param id classId
+     * @return List - SelfStudyStudentsDto (id, stuNum, memberName, gender)
+     * @author 배태현
+     */
+    @Override
+    public List<SelfStudyStudentsDto> findBySelfStudyCategory(Long id) {
+        return queryFactory.from(selfStudy)
+                .select(Projections.fields(SelfStudyStudentsDto.class,
+                        member.id,
+                        member.stuNum,
+                        member.memberName,
+                        member.gender
+                        )
+                )
+                .where(member.stuNum.like(id+"%"))
+                .innerJoin(selfStudy.member, member)
+                .orderBy(member.stuNum.asc())
                 .fetch();
     }
 }

--- a/src/main/java/com/server/Dotori/domain/self_study/service/Impl/SelfStudyServiceImpl.java
+++ b/src/main/java/com/server/Dotori/domain/self_study/service/Impl/SelfStudyServiceImpl.java
@@ -46,7 +46,7 @@ public class SelfStudyServiceImpl implements SelfStudyService {
      */
     @Override
     @Transactional
-    public synchronized void requestSelfStudy(DayOfWeek dayOfWeek, int hour) {
+    public void requestSelfStudy(DayOfWeek dayOfWeek, int hour) {
         validDayOfWeekAndHour(dayOfWeek, hour, ErrorCode.SELF_STUDY_CANT_REQUEST_DATE, ErrorCode.SELF_STUDY_CANT_REQUEST_TIME);
 
         Member currentMember = currentMemberUtil.getCurrentMember();

--- a/src/test/java/com/server/Dotori/domain/self_study/service/SelfStudyStatusServiceTest.java
+++ b/src/test/java/com/server/Dotori/domain/self_study/service/SelfStudyStatusServiceTest.java
@@ -8,7 +8,9 @@ import com.server.Dotori.domain.member.enumType.Role;
 import com.server.Dotori.domain.member.enumType.SelfStudyStatus;
 import com.server.Dotori.domain.member.repository.member.MemberRepository;
 import com.server.Dotori.domain.self_study.SelfStudy;
+import com.server.Dotori.domain.self_study.SelfStudyCount;
 import com.server.Dotori.domain.self_study.dto.SelfStudyStudentsDto;
+import com.server.Dotori.domain.self_study.repository.SelfStudyCountRepository;
 import com.server.Dotori.domain.self_study.repository.SelfStudyRepository;
 import com.server.Dotori.global.exception.DotoriException;
 import com.server.Dotori.global.util.CurrentMemberUtil;
@@ -52,6 +54,7 @@ class SelfStudyStatusServiceTest {
     @Autowired private CurrentMemberUtil currentMemberUtil;
     @Autowired private SelfStudyService selfStudyService;
     @Autowired private SelfStudyRepository selfStudyRepository;
+    @Autowired private SelfStudyCountRepository selfStudyCountRepository;
     @Autowired
     EntityManager em;
 
@@ -95,6 +98,7 @@ class SelfStudyStatusServiceTest {
 
         assertEquals(SelfStudyStatus.APPLIED, currentMemberUtil.getCurrentMember().getSelfStudyStatus());
         assertEquals(1 , selfStudyRepository.findAll().size());
+        assertEquals(1L, selfStudyCountRepository.findSelfStudyCountById(1L).getCount());
     }
 
     @Test
@@ -192,6 +196,12 @@ class SelfStudyStatusServiceTest {
         ).limit(50).collect(Collectors.toList());
 
         selfStudyRepository.saveAll(selfStudyList);
+
+        SelfStudyCount findCount = selfStudyCountRepository.findSelfStudyCountById(1L);
+
+        for (int i = 0; i < 50; i++) {
+            findCount.addCount();
+        }
 
         //when //then
         assertThrows(

--- a/src/test/java/com/server/Dotori/domain/self_study/service/SelfStudyStatusServiceTest.java
+++ b/src/test/java/com/server/Dotori/domain/self_study/service/SelfStudyStatusServiceTest.java
@@ -114,7 +114,7 @@ class SelfStudyStatusServiceTest {
 
         latch.await();
 
-        long count = selfStudyRepository.count();
+        Long count = selfStudyCountRepository.findSelfStudyCountById(1L).getCount();
 
         System.out.println("count = " + count);
     }


### PR DESCRIPTION
### 제가 한 일이에요
* 자습신청 카운트를 따로 관리하는 Entity를 생성하여 해당 카운트를 JPA 비관적 Lock을 이용하여 for update 쿼리로 조회할 수 있도록 하여 JPA 비관적 Lock을 적용하였습니다.
* 스케줄러에 SelfStudyCount Entity의 count를 초기화해주는 로직을 추가해주었습니다.
* 자습신청 관련 querydsl 조회 쿼리 memberRepository에서 selfStudyRepository로 이동시켰습니다.
> JPA 비관적 Lock 적용하고 동시성 테스트 해봤는데 정상적으로 작동 되는 점 확인했습니다.

### JPA 비관적 Lock이 적용된 쿼리의 예시 (for update)
![스크린샷 2022-05-16 오후 12 00 58](https://user-images.githubusercontent.com/69895394/168525647-a0d62743-e06f-4e5a-9d6c-e020bc2574a0.png)

