### PR TITLE
:fire: :: MemberRepository 부분에서 마사지 상태 조회 기능을 더이상 사용하지 않아 삭제

### DIFF
--- a/src/main/java/com/server/Dotori/domain/member/repository/member/MemberRepositoryCustom.java
+++ b/src/main/java/com/server/Dotori/domain/member/repository/member/MemberRepositoryCustom.java
@@ -24,8 +24,6 @@ public interface MemberRepositoryCustom {
 
     void updateMassageStatus();
 
-    List<MassageStudentsDto> findMemberByMassageStatus();
-
     List<Member> findStuInfoByMemberName(String memberName);
 
     List<FindStusDto> findAllStuOfRulePage();

--- a/src/main/java/com/server/Dotori/domain/member/repository/member/MemberRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/domain/member/repository/member/MemberRepositoryImpl.java
@@ -140,25 +140,6 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .execute();
     }
 
-    /**
-     * 안마의자 신청을 한 학생들을 조회하는 쿼리
-     * @return List<MassageStudentsDto> (id, stuNum, memberName)
-     * @author 김태민
-     */
-    @Override
-    public List<MassageStudentsDto> findMemberByMassageStatus() {
-        return queryFactory
-                .from(member)
-                .select(Projections.fields(MassageStudentsDto.class,
-                        member.id, member.memberName, member.stuNum)
-                )
-                .where(
-                        member.massageStatus.eq(MassageStatus.APPLIED)
-                )
-                .orderBy(member.createdDate.asc())
-                .fetch();
-    }
-
     @Override
     public List<Member> findStuInfoByMemberName(String memberName) {
         return queryFactory.from(member)


### PR DESCRIPTION
* 기존 findByMassageMember 에서 안마의자 조회가 이루어졌는데 이후 MassageRepository부분에서 따로 안마의자 조회 기능을 만들어 findByMassageMember 메소드 부분이 쓸모가 없어져 삭제 했습니다.