### PR TITLE
Service로직에서 try문 제거

### DIFF
--- a/src/main/java/com/server/Dotori/domain/board/service/Impl/BoardServiceImpl.java
+++ b/src/main/java/com/server/Dotori/domain/board/service/Impl/BoardServiceImpl.java
@@ -44,16 +44,16 @@ public class BoardServiceImpl implements BoardService {
     @Override
     public Board createBoard(BoardDto boardDto, List<MultipartFile> multipartFileList) {
         Member currentMember = currentMemberUtil.getCurrentMember();
-        try {
-            List<String> uploadFile = s3Service.uploadFile(multipartFileList);
-            Board board = boardRepository.save(boardDto.saveToEntity(currentMember));
-            for (String uploadFileUrl : uploadFile) {
-                boardImageRepository.save(saveToUrl(board,uploadFileUrl));
-            }
-            return board;
-        } catch (NullPointerException e) {
+
+        if(multipartFileList == null){
             return boardRepository.save(boardDto.saveToEntity(currentMember));
         }
+        List<String> uploadFile = s3Service.uploadFile(multipartFileList);
+        Board board = boardRepository.save(boardDto.saveToEntity(currentMember));
+        for (String uploadFileUrl : uploadFile) {
+            boardImageRepository.save(saveToUrl(board,uploadFileUrl));
+        }
+        return board;
     }
 
     private BoardImage saveToUrl(Board board,String uploadFileUrl) {
@@ -131,15 +131,14 @@ public class BoardServiceImpl implements BoardService {
     public void deleteBoard(Long boardId) {
         Board board = getBoard(boardId);
         List<BoardImage> boardImages = boardImageRepository.getBoardImageByBoardId(boardId);
-        try {
-            for(BoardImage boardImage : boardImages){
-                s3Service.deleteFile(boardImage.getUrl().substring(54));
-                boardImageRepository.deleteByBoardId(board.getId());
-            }
-            boardRepository.deleteById(board.getId());
-        } catch (NullPointerException e) {
+        if(boardImages == null){
             boardRepository.deleteById(board.getId());
         }
+        for(BoardImage boardImage : boardImages){
+            s3Service.deleteFile(boardImage.getUrl().substring(54));
+            boardImageRepository.deleteByBoardId(board.getId());
+        }
+        boardRepository.deleteById(board.getId());
     }
 
     /**

--- a/src/main/java/com/server/Dotori/domain/massage/service/Impl/MassageServiceImpl.java
+++ b/src/main/java/com/server/Dotori/domain/massage/service/Impl/MassageServiceImpl.java
@@ -57,16 +57,11 @@ public class MassageServiceImpl implements MassageService {
         countValidate(count);
         Member currentMember = currentMemberUtil.getCurrentMember();
         massageStatusValidate(currentMember, MassageStatus.CAN);
-
-        try {
-            massageRepository.save(Massage.builder()
-                    .member(currentMember)
-                    .build()
-            );
-            massageCount.addCount();
-        } catch (DataIntegrityViolationException e) {
-            throw new DotoriException(ErrorCode.MASSAGE_ALREADY);
-        }
+        massageRepository.save(Massage.builder()
+                .member(currentMember)
+                .build()
+        );
+        massageCount.addCount();
         currentMember.updateMassage(MassageStatus.APPLIED);
         log.info("Current MassageRequest Student Count is {}", count);
     }

--- a/src/main/java/com/server/Dotori/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/server/Dotori/domain/member/service/impl/MemberServiceImpl.java
@@ -46,18 +46,15 @@ public class MemberServiceImpl implements MemberService {
         String password = memberDto.getPassword();
         String email = memberDto.getEmail();
 
-        try {
-            if(!emailCertificateRepository.existsByEmail(email)){
-                if (!memberRepository.existsByEmailAndStuNum(email, stuNum)) {
-                    Member result = memberRepository.save(
-                            memberDto.toEntity(passwordEncoder.encode(password))
-                    );
-                    return result.getId();
-                } else throw new DotoriException(ErrorCode.MEMBER_ALREADY);
-            } else throw new DotoriException(ErrorCode.MEMBER_EMAIL_HAS_NOT_BEEN_CERTIFICATE);
-        } catch (DataIntegrityViolationException e) {
+        if(emailCertificateRepository.existsByEmail(email))
+            throw new DotoriException(ErrorCode.MEMBER_EMAIL_HAS_NOT_BEEN_CERTIFICATE);
+        if(memberRepository.existsByEmailAndStuNum(email, stuNum))
             throw new DotoriException(ErrorCode.MEMBER_ALREADY);
-        }
+        Member result = memberRepository.save(
+            memberDto.toEntity(passwordEncoder.encode(password))
+        );
+
+        return result.getId();
     }
 
     /**

--- a/src/main/java/com/server/Dotori/domain/self_study/service/Impl/SelfStudyServiceImpl.java
+++ b/src/main/java/com/server/Dotori/domain/self_study/service/Impl/SelfStudyServiceImpl.java
@@ -56,19 +56,14 @@ public class SelfStudyServiceImpl implements SelfStudyService {
         isSmallerThanFifty(findCount.getCount()); // count가 50 미만인지 checking
         isVerifiedSelfStudy(SelfStudyStatus.CAN, ErrorCode.SELF_STUDY_ALREADY); // 회원의 자습신청 상태가 CAN인지 checking
 
-        try {
-            currentMember.updateSelfStudy(SelfStudyStatus.APPLIED);
+        currentMember.updateSelfStudy(SelfStudyStatus.APPLIED);
 
-            findCount.addCount();
+        findCount.addCount();
 
-            selfStudyRepository.save(SelfStudy.builder()
-                    .member(currentMember)
-                    .build()
-            );
-
-        } catch (DataIntegrityViolationException e) { // TODO : controller advice로 처리하게 바꾸고 서비스 로직에서 try/catch 삭제하기
-            throw new DotoriException(ErrorCode.SELF_STUDY_ALREADY);
-        }
+        selfStudyRepository.save(SelfStudy.builder()
+                .member(currentMember)
+                .build()
+        );
     }
 
     /**

--- a/src/main/java/com/server/Dotori/global/exception/handler/DotoriExceptionHandler.java
+++ b/src/main/java/com/server/Dotori/global/exception/handler/DotoriExceptionHandler.java
@@ -3,6 +3,7 @@ package com.server.Dotori.global.exception.handler;
 import com.server.Dotori.global.exception.DotoriException;
 import com.server.Dotori.global.exception.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -38,4 +39,9 @@ public class DotoriExceptionHandler {
 
     }
 
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(DataIntegrityViolationException e){
+        log.error("handleDataIntegrityViolationException throw DataIntegrityViolationException");
+        return ErrorResponse.toResponseEntity(HttpStatus.CONFLICT, e.getMessage());
+    }
 }

--- a/src/test/java/com/server/Dotori/domain/member/exception/MemberExceptionTest.java
+++ b/src/test/java/com/server/Dotori/domain/member/exception/MemberExceptionTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
@@ -90,7 +91,7 @@ public class MemberExceptionTest {
         memberService.signup(memberDto1);
 
         // then
-        Assertions.assertThrows(DotoriException.class, () -> memberService.signup(memberDto2));
+        Assertions.assertThrows(DataIntegrityViolationException.class, () -> memberService.signup(memberDto2));
     }
 
     @Test

--- a/src/test/java/com/server/Dotori/domain/self_study/service/SelfStudyStatusServiceTest.java
+++ b/src/test/java/com/server/Dotori/domain/self_study/service/SelfStudyStatusServiceTest.java
@@ -18,6 +18,7 @@ import com.server.Dotori.global.util.CurrentMemberUtil;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
@@ -181,7 +182,7 @@ class SelfStudyStatusServiceTest {
 
         //when //then
         assertThrows(
-                DotoriException.class,
+                DataIntegrityViolationException.class,
                 () -> selfStudyService.requestSelfStudy(DayOfWeek.MONDAY, 20)
         );
     }


### PR DESCRIPTION
## 한일
* 기존에 서비스로직에 있던 try문을 제거했습니다.
* 가능한건 if문으로 대체하였고, 대체가 안되는 try문은 exceptionHandler에서 처리하도록 변경했습니다.