### PR TITLE
자습체크 업데이트 쿼리에 execute추가

### DIFF
--- a/src/main/java/com/server/Dotori/domain/member/repository/member/MemberRepositoryImpl.java
+++ b/src/main/java/com/server/Dotori/domain/member/repository/member/MemberRepositoryImpl.java
@@ -182,8 +182,9 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
     public void updateSelfStudyCheck() {
         queryFactory
                 .update(member)
-                .where(member.selfStudyCheck.eq(true))
-                .set(member.selfStudyCheck, false);
+                .set(member.selfStudyCheck, false)
+                .where(member.selfStudyCheck.isTrue())
+                .execute();
     }
 
     private List<FindStusDto> makeFindStusResponse(List<Member> result){


### PR DESCRIPTION
## 한일
* MemberRepository의 updateSelfStudyCheck메서드에 execute를 추가했습니다.
<img width="409" alt="스크린샷 2022-09-15 오후 12 25 40" src="https://user-images.githubusercontent.com/80161826/190306854-64816a96-f883-4c17-95cf-6d81c3930949.png">
