### PR TITLE
massage_count ID값이 변경되어 안찾아지는 버그 수정

### DIFF
--- a/src/main/java/com/server/Dotori/domain/massage/MassageCount.java
+++ b/src/main/java/com/server/Dotori/domain/massage/MassageCount.java
@@ -9,7 +9,7 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class MassageCount {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
     private Long id;
 
     @Column(name = "massage_count")


### PR DESCRIPTION
<img width="614" alt="스크린샷 2022-10-14 오전 8 07 21" src="https://user-images.githubusercontent.com/81404026/195726664-68bf9cdb-95db-45b2-a1e1-16b5c8c12e57.png">

위와 같이 GeneratedValue가 존재하여 값이 변경되는것이여서 GeneratedValue를 삭제하였습니다


